### PR TITLE
Add employee-onboarding workspace and initial docs

### DIFF
--- a/work/employee-onboarding/AGENTS.md
+++ b/work/employee-onboarding/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+These instructions apply only within work/employee-onboarding.
+
+- Keep documentation concise and structured with headings.
+- Record key decisions with dates in decisions.md.
+- Store any produced specs or artifacts in output/.

--- a/work/employee-onboarding/README.md
+++ b/work/employee-onboarding/README.md
@@ -1,0 +1,24 @@
+# Employee Onboarding
+
+## Role
+AI employee for the dopamine environment, responsible for scoped onboarding setup and documentation.
+
+## Responsibilities
+- Maintain onboarding workspace within the employee folder.
+- Document assumptions, tasks, and decisions for traceability.
+- Record outputs in the output/ directory.
+
+## Current focus
+- Establish baseline onboarding structure.
+- Review existing company context files under work/.
+
+## Dependencies
+- work/index.md (if present)
+- work/decisions.md (if present)
+- work/state.md (if present)
+
+## End of Task Summary
+- What I did: Created the employee-onboarding folder structure, initial documentation, and local AGENTS.md; checked for company context files; initialized work/state.md.
+- What I decided: Used the "onboarding" employee ID and documented the scope restriction for AGENTS.md updates.
+- What remains open: Awaiting an assignment that begins with "Employee"; confirmation on AGENTS.md expectations outside this folder.
+- What another employee should pick up next: Monitor for an "Employee"-prefixed assignment and update tasks/outputs accordingly.

--- a/work/employee-onboarding/decisions.md
+++ b/work/employee-onboarding/decisions.md
@@ -1,0 +1,4 @@
+# Decisions
+
+- 2025-02-14: Selected employee ID "onboarding" to reflect onboarding/setup scope and keep the identifier short and descriptive.
+- 2025-02-14: Created a local AGENTS.md inside the employee folder to address the request without modifying files outside the allowed scope.

--- a/work/employee-onboarding/notes.md
+++ b/work/employee-onboarding/notes.md
@@ -1,0 +1,12 @@
+# Notes
+
+## Assumptions
+- No assignment is active because the prompt does not begin with "Employee".
+- Work outside the employee folder is restricted except for required company context files.
+
+## Open questions
+- Should an AGENTS.md file exist outside the employee folder?
+- Is there a preferred employee ID naming convention beyond the provided format?
+
+## Risks or uncertainties
+- Potential conflict between the request to update agents.md and the restriction on modifying files outside the employee folder.

--- a/work/employee-onboarding/tasks.md
+++ b/work/employee-onboarding/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+## Active tasks
+- [ ] Await an assignment that starts with "Employee".
+
+## Completed tasks
+- [x] Initialized onboarding folder structure.
+- [x] Documented onboarding metadata.

--- a/work/state.md
+++ b/work/state.md
@@ -1,0 +1,1 @@
+2025-02-14: Initialized employee-onboarding workspace with required files and structure.


### PR DESCRIPTION
### Motivation
- Provide a dedicated onboarding workspace for a new AI employee to follow the onboarding spec and keep work scoped to an employee folder.
- Initialize the minimal required documentation and artifacts so future tasks and outputs have a consistent place to land.
- Avoid modifying global company files while still recording the workspace creation in the company state.

### Description
- Create `work/employee-onboarding/` with `README.md`, `notes.md`, `tasks.md`, `decisions.md`, and `AGENTS.md` containing onboarding guidance and decisions.
- Add an `output/` directory inside the employee folder as the canonical place for generated specs and artifacts.
- Populate `README.md` with role, responsibilities, dependencies, and an end-of-task summary, and record decisions in `decisions.md`.
- Add `work/state.md` with a one-line entry noting the workspace initialization.

### Testing
- No automated tests or CI runs were executed because this change is documentation-only.
- Local file creation and validation were performed to ensure the new files and directories exist and contain the expected content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d9338217c83209af10b1eec5f5541)