### PR TITLE
Add PM synthesis, execution plan, and employee prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+## End of Task Summary
+- Current project health: Early-stage planning is solid; core principles and MVP boundaries are documented, but implementation specs are still incomplete.
+- Immediate next actions: Finalize org creation path, delay policy, and external email scope; complete email pipeline, command grammar, and template specs.
+- Key risks: Scope creep into web UI or dashboards, inconsistent async timing behavior, and unclear email command authentication.
+- Confidence level (low / medium / high): Medium

--- a/work/employee-pm/output/employee-prompts.md
+++ b/work/employee-pm/output/employee-prompts.md
@@ -1,0 +1,16 @@
+# Employee Prompts
+
+Employee 04 — Email System Engineer
+You already documented the threading rules and data model in `work/employee-04/output/email-system-design.md`. Build on that by writing an executable inbound/outbound email pipeline spec for v0. Include: transport choices, parsing steps, threading flow, storage writes, delivery flow, bounce handling, and failure paths. Keep it email-only and aligned to MVP scope. Output to `work/employee-04/output/email-pipeline-spec.md`.
+
+Employee 03 — AI Coworker Behavior Lead
+You defined behavior policy and examples in `work/employee-03/output/behavior-spec.md` and `work/employee-03/output/email-examples.md`. Now produce a concrete v0 response format and a single delay policy. Specify: subject prefixes, required “Work Notes” section fields, tone constraints, signatures, and a deterministic delay window (reconcile the 5–30 min vs 1–24h conflict). Output to `work/employee-03/output/response-format-and-delay.md`.
+
+Employee 01 — Founding Engineer
+You set the system boundary and core entities in `work/employee-01/output/system-boundary.md`. Draft the email command grammar for v0: org creation, hire coworker, pause/resume coworker, update role. Include sender validation/auth assumptions and any bootstrap path. Keep everything email-only and aligned to the MVP anti-features. Output to `work/employee-01/output/email-command-spec.md`.
+
+Employee 02 — Product Designer
+You outlined email-native UX in `work/employee-02/output/employee-02-ux.md`. Convert those concepts into concrete email templates (subject + body) for: task assignment, hire confirmation, clarification request, progress update, and digest. Keep all interaction inside email, no web UI. Output to `work/employee-02/output/email-templates-v0.md`.
+
+Employee 05 — MVP Scope Police
+You delivered scope guardrails in `work/employee-05/output/mvp-scope-police.md`. Create a v0 acceptance checklist and red-line scope warnings that can be used to gate build decisions. Keep it short and strict. Output to `work/employee-05/output/v0-acceptance-checklist.md`.

--- a/work/employee-pm/output/founder-guidance.md
+++ b/work/employee-pm/output/founder-guidance.md
@@ -1,0 +1,21 @@
+# Founder Guidance
+
+## What you should do next
+- Decide the **org creation bootstrap path** for v0 (email-only self-serve vs manual/admin creation).
+- Choose a **single response delay policy** (minutes vs hours) so implementation is consistent.
+- Confirm whether **external email** (non-org domains) is in scope for v0.
+
+## Decisions blocked on you
+- **Auth/verification model:** how to validate who can issue admin commands via email.
+- **Email infrastructure choice:** provider for inbound/outbound (e.g., SMTP vs API-based). This affects pipeline design.
+- **Tone/brand constraints:** how “human” and playful the AI should be (to reconcile “boring is good” with light delight).
+
+## What you should NOT think about yet
+- Integrations, dashboards, analytics, multi-org management, or performance optimization.
+- Cross-thread memory or knowledge bases.
+- Billing or pricing complexity.
+
+## Risks if execution continues unchecked
+- **Scope creep** into web UI or status dashboards, violating “email is the UI.”
+- **Inconsistent behavior** if delay policy and admin command syntax are not decided early.
+- **Security ambiguity** around who can command AI coworkers via email.

--- a/work/employee-pm/output/plan.md
+++ b/work/employee-pm/output/plan.md
@@ -1,0 +1,33 @@
+# Execution Plan (Employee PM)
+
+## Plan principles
+- Keep v0 strictly email-only.
+- Each task outputs a concrete, written artifact in the assignee’s `output/` folder.
+- Prefer parallel work; avoid overlap and premature optimization.
+
+## Tasks
+
+### Task 1 — Email pipeline spec (Employee 04 — Email System Engineer)
+- **Objective:** Turn threading/data model into an executable inbound/outbound pipeline spec (transport choices, parsing steps, delivery flow, bounce handling).
+- **Expected output:** `work/employee-04/output/email-pipeline-spec.md`
+- **Notes:** Must align with threading rules already documented and MVP constraints (no dashboards).
+
+### Task 2 — AI coworker response template + delay policy (Employee 03 — AI Behavior Lead)
+- **Objective:** Define a concrete v0 response format (subject prefixes, Work Notes section, signatures) and a reconciled delay policy (single delay window).
+- **Expected output:** `work/employee-03/output/response-format-and-delay.md`
+- **Notes:** Use the existing behavior policy and examples; keep delays human-like but deterministic enough for MVP.
+
+### Task 3 — Email command grammar (Employee 01 — Founding Engineer)
+- **Objective:** Specify the exact email command syntax for org creation, hire coworker, pause/resume, and role update. Include validation/auth assumptions.
+- **Expected output:** `work/employee-01/output/email-command-spec.md`
+- **Notes:** Must be email-only; clarify any bootstrap path.
+
+### Task 4 — Email-native UX templates (Employee 02 — Product Designer)
+- **Objective:** Convert core UX concepts into email templates (compose/assign, hire confirmation, digest, clarification request).
+- **Expected output:** `work/employee-02/output/email-templates-v0.md`
+- **Notes:** No web UI; templates must live fully inside email bodies/subjects.
+
+### Task 5 — MVP acceptance checklist (Employee 05 — MVP Scope Police)
+- **Objective:** Create a concise v0 acceptance checklist + red-line scope warnings to validate against build work.
+- **Expected output:** `work/employee-05/output/v0-acceptance-checklist.md`
+- **Notes:** Should explicitly call out anything that would violate “email is the UI.”

--- a/work/employee-pm/output/synthesis.md
+++ b/work/employee-pm/output/synthesis.md
@@ -1,0 +1,29 @@
+# Synthesis (Employee PM)
+
+## What is clearly decided
+- **North star:** Email-first company simulator; async by default; no chat, no real-time presence, no dashboards. AI coworkers behave like imperfect, slow human coworkers who communicate only through email threads. (Context files)
+- **System boundary (v0):** Core loop is email ingest → interpret → respond within a thread. Anything beyond receiving, threading, routing, and replying is out of scope. (Employee 01)
+- **MVP scope guardrails:** Email-only org setup, hire coworker via email, task assignment via email thread, minimal thread memory, intentional delay, audit trail in email, simple admin commands via email, single LLM provider. Explicit bans: web app UI beyond signup, chat, dashboards, integrations, project management views, real-time presence. (Employee 05)
+- **AI behavior model:** Read threads like a human, imperfect understanding is acceptable, delays are intentional, respond only when needed, loop in other coworkers via CC/forward, and make assumptions explicit. (Employee 03)
+- **Email/threading model:** Immutable email messages, thread linkage via headers first with subject fallback; forwards default to new thread; internal vs external classification by org domains; rich metadata stored but not shown. (Employee 04)
+- **UX framing:** All user-facing interactions are email-native (threads, subject tags, templates). Visibility comes from “work notes” and digest emails, not presence signals. (Employee 02)
+
+## What is still ambiguous
+- **Org creation mechanism:** Employee 05 suggests email-based org setup; Employee 01 allows manual/CLI creation. Need a single, explicit v0 path (email-only vs manual bootstrap).
+- **Admin controls:** MVP includes email commands (pause/resume/update role), but no spec exists for syntax, authentication, or who can issue commands.
+- **Response delay policy:** Employee 03 allows hours-long delays; Employee 05 suggests 5–30 minutes. Need a single, explicit delay policy for v0.
+- **UI boundaries:** Employee 02 references “core screens” (Inbox/Thread/Compose) as conceptual email client views, while Employee 05 bans dashboards/web UI. Clarify that these are email-client-native patterns (templates/subjects), not a new web app.
+- **External email policy:** Employee 04 defines internal/external handling, but MVP scope doesn’t state whether external recipients are supported in v0.
+
+## What is missing but required to build v0
+- **Concrete inbound/outbound email pipeline spec:** transport choice, parsing stack, webhook/inbox provider, bounce handling behaviors aligned to MVP.
+- **Prompting and role instruction templates:** defined per-role system instructions, email reply format (incl. Work Notes), and default signatures.
+- **Email command grammar:** exact subject/body syntax for hire/pause/resume/role update, and validation rules.
+- **Security/auth rules:** who can create an org/hire coworkers, and how sender identity is verified (domain allowlist, reply token, etc.).
+- **Minimal storage schema and API surfaces:** how orgs, mailboxes, threads, messages are created and updated at runtime.
+- **Test/QA scenarios:** end-to-end email loop, threading edge cases, delay scheduling, and failure handling.
+
+## Contradictions between employees
+- **Delay window:** Employee 03’s “respond later (1–24 hours)” conflicts with Employee 05’s “5–30 minutes randomized” MVP delay; needs reconciliation.
+- **Org setup:** Employee 05’s email-only setup conflicts with Employee 01’s allowance for admin/CLI creation; must pick one for v0.
+- **UI framing risk:** Employee 02’s “core screens” could be misread as a web app; must explicitly constrain to email client conventions to align with Employee 05’s anti-feature list.


### PR DESCRIPTION
### Motivation
- Capture the current state of work and decisions in a single Product Manager artifact to reduce ambiguity across contributors.  
- Reconcile outstanding questions about org bootstrap, delay policy, and external email scope so implementation can proceed.  
- Provide a concrete execution plan that assigns follow-up tasks to existing employees and produces actionable artifacts.  
- Give the founder clear guidance on blocked decisions and immediate next steps.  

### Description
- Add PM synthesis documenting what is decided, ambiguous, missing, and contradictory in `work/employee-pm/output/synthesis.md`.  
- Add an execution plan assigning five concrete tasks with expected outputs in `work/employee-pm/output/plan.md`.  
- Add ready-to-run prompts for employees in `work/employee-pm/output/employee-prompts.md` and founder guidance in `work/employee-pm/output/founder-guidance.md`.  
- Add an end-of-task summary to the repository `README.md` under `## End of Task Summary` to surface project health and next actions.  

### Testing
- No automated tests were run because these are documentation-only changes.  
- Validation consisted of writing artifacts into the expected `work/employee-pm/output/` paths and checking content presence.  
- Manual review confirmed the new files exist and summarize decisions and next tasks.  
- No changes were made to runtime code or infrastructure, so no CI build or runtime validation was required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f04de5d7883208f9edbf95593b3d4)