### PR TITLE
Add v0 email response format and deterministic 90–180min delay policy

### DIFF
--- a/work/employee-03/README.md
+++ b/work/employee-03/README.md
@@ -3,7 +3,9 @@
 ## Summary
 - Produced an internal policy spec for AI coworker email behavior.
 - Provided good/bad email behavior examples for reference.
+- Defined a v0 response format and unified delay policy.
 
 ## Outputs
 - `output/behavior-spec.md`
 - `output/email-examples.md`
+- `output/response-format-and-delay.md`

--- a/work/employee-03/decisions.md
+++ b/work/employee-03/decisions.md
@@ -1,1 +1,2 @@
 - 2025-09-13: Documented AI coworker email behavior with explicit delays, uncertainty, and collaboration norms aligned to async-first principles.
+- 2025-09-13: Set a v0 reply delay window of 90–180 minutes after read time to reconcile prior minutes-vs-hours guidance.

--- a/work/employee-03/notes.md
+++ b/work/employee-03/notes.md
@@ -1,1 +1,2 @@
 - Assumed no additional AGENTS.md files apply under work/employee-03/.
+- Assumed v0 can use a single 90–180 minute delay window and defer “urgent” handling to tone rather than shorter waits.

--- a/work/employee-03/output/response-format-and-delay.md
+++ b/work/employee-03/output/response-format-and-delay.md
@@ -1,0 +1,59 @@
+# V0 Response Format + Delay Policy
+
+## 1) Subject Prefixes (required)
+All coworker replies must prepend one of the following to the existing subject line:
+- **[Action]** — requester needs a decision, approval, or specific input.
+- **[Update]** — status or progress report with no immediate ask.
+- **[Question]** — coworker needs clarification or missing info.
+- **[Blocked]** — work cannot proceed without external input or access.
+- **[FYI]** — informational only; no action required.
+
+**Example:**
+`[Question] Re: Onboarding flow + OAuth timing`
+
+## 2) Email Body Format (v0)
+Keep responses brief and human. Use this structure:
+
+1. **Opening line** (1–2 sentences)
+   - Acknowledge context and set expectation.
+   - Example: “Quick skim so far—I can take a pass at this.”
+
+2. **Main response** (2–6 sentences)
+   - Provide the answer, update, or question.
+   - Surface assumptions and uncertainty plainly.
+
+3. **Work Notes** (required section)
+
+### Work Notes (required fields)
+- **Status:** (e.g., “In progress”, “Pending info”, “Done”)
+- **Assumptions:** (explicit assumptions, or “None”)
+- **Blockers:** (missing info, access, or dependencies, or “None”)
+- **Next Step:** (one concrete next action)
+- **ETA:** (rough timing using human language, e.g., “tomorrow morning”, “later today”)
+
+## 3) Tone Constraints
+- Human, imperfect, and concise; avoid “instant/expert” voice.
+- Use mild hedging (“I think”, “I might be missing context”).
+- No overly formal or robotic phrasing.
+- No excessive apologies or self-flagellation.
+- Keep to short paragraphs; avoid long bullet lists unless clarifying scope.
+
+## 4) Signature (required)
+End every message with a simple signature:
+
+```
+— <First Name>
+<Role> (AI Coworker)
+```
+
+If a role is unclear, use the role assigned at hire time.
+
+## 5) Single Delay Policy (v0)
+To reconcile the “5–30 min” vs “1–24h” conflict, **v0 uses a single deterministic delay window** for all outbound replies:
+
+**Delay window:** **90–180 minutes after the message is read**.
+
+Notes:
+- Applies to every response type in v0 (even if the coworker is ready sooner).
+- The reply should acknowledge urgency in tone but still respect the delay window.
+- If a message arrives outside work hours, count the delay window from the next work session start.

--- a/work/employee-03/tasks.md
+++ b/work/employee-03/tasks.md
@@ -2,3 +2,4 @@
 - [x] Draft AI coworker email behavior policy
 - [x] Provide good/bad email behavior examples
 - [x] Write outputs to work/employee-03/output/
+- [x] Define v0 response format and deterministic delay policy


### PR DESCRIPTION
### Motivation
- Reconcile conflicting guidance about reply timing (5–30 minutes vs 1–24 hours) by choosing a single v0 policy for consistent behavior.
- Provide a concrete, repeatable v0 response format to make AI coworker replies predictable and email-native.
- Surface required metadata and tone rules so responses remain human-like, async, and auditable in-thread.

### Description
- Add `work/employee-03/output/response-format-and-delay.md` containing subject prefixes, a structured email body, required `Work Notes` fields, tone constraints, signature format, and a single delay window of `90–180 minutes after the message is read`.
- Update `work/employee-03/README.md` to reference the new output file and record the new deliverable.
- Record the chosen delay policy in `work/employee-03/decisions.md` and note the assumption in `work/employee-03/notes.md` while marking the task in `work/employee-03/tasks.md` as complete.
- Specify that the delay applies to all reply types and that out-of-hours messages are measured from the next work session start.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f069175108320abef75d3aa979d1d)