### PR TITLE
Add v0 email command grammar for org and coworker management

### DIFF
--- a/work/employee-01/README.md
+++ b/work/employee-01/README.md
@@ -3,3 +3,4 @@
 ## Summary
 - Produced a minimal system boundary spec, core entity list, and hello-world flow in output/.
 - Logged decisions and notes, and updated tasks.
+- Drafted v0 email command grammar for org/coworker management in output/.

--- a/work/employee-01/decisions.md
+++ b/work/employee-01/decisions.md
@@ -1,3 +1,4 @@
 # Decisions
 
 - Kept the system boundary limited to the email task loop (ingest → interpret → respond) to align with “email is the UI” and avoid feature creep.
+- For v0 email command auth, assumed allowlist-first with optional bootstrap token to avoid any UI-based setup.

--- a/work/employee-01/output/email-command-spec.md
+++ b/work/employee-01/output/email-command-spec.md
@@ -1,0 +1,137 @@
+# Email Command Spec v0 (MVP)
+
+## Purpose
+Define the minimal email-only command grammar to manage organizations and coworkers (create org, hire coworker, pause/resume, update role). This spec assumes no UI and no real-time systems.
+
+## Scope / Anti-Features Alignment
+- **Email is the UI**: all commands are sent via email to a control address.
+- **Async only**: no chat, live status, or dashboards.
+- **Minimal HR**: no payroll, scheduling, performance tracking, or complex permissions.
+- **Single-thread command execution**: each command is handled within its own email thread.
+
+## Command Transport
+- **Control address**: `control@dopocorp.com` (or tenant-specific alias `control@<org-domain>` once org exists).
+- **Command format**: plain text in email body (subject ignored except for routing).
+- **One command per email**.
+
+## Sender Validation & Auth Assumptions (v0)
+1. **Allowlist-based admin**: only emails in an allowlist are allowed to issue commands.
+2. **Domain verification**: for org creation, the sender’s email domain is treated as the org domain unless explicitly specified.
+3. **Bootstrap secret (optional)**: an optional one-time token may be required in the body for org creation if no allowlist exists.
+4. **No delegated admin**: only the initial admin email(s) may issue commands (until role management exists).
+
+If a command fails auth, the system replies with an error and takes no action.
+
+## Bootstrap Path (Email-Only)
+- **Path A (allowlist)**: Operator pre-loads a single admin email; that admin can email `CREATE ORG`.
+- **Path B (token)**: Operator sends a one-time bootstrap token to the intended admin. The admin includes it in the `CREATE ORG` command body.
+
+No UI, no API keys, no dashboards.
+
+---
+
+## Command Grammar
+
+### Conventions
+- Keywords are uppercase.
+- Required fields are plain `key: value` lines.
+- Optional fields are marked `(optional)`.
+- Identifiers should be stable and human-readable (e.g., `coworker_id: eng-1`).
+
+### 1) Create Organization
+```
+CREATE ORG
+name: <Organization Name>
+admin_email: <Admin Email>
+(org_domain: <domain>) (optional)
+bootstrap_token: <token> (optional; required if no allowlist)
+```
+**Notes**
+- `org_domain` defaults to the sender’s domain.
+- `admin_email` must match the sender.
+
+### 2) Hire Coworker
+```
+HIRE COWORKER
+coworker_id: <id>
+name: <Full Name>
+role: <Role Title>
+email_alias: <local-part>@<org-domain>
+model: <model_name> (optional)
+```
+**Notes**
+- `email_alias` must be within the org domain.
+- `coworker_id` is unique within the org.
+
+### 3) Pause Coworker
+```
+PAUSE COWORKER
+coworker_id: <id>
+reason: <short reason> (optional)
+```
+**Effect**
+- Coworker stops responding to new threads until resumed.
+
+### 4) Resume Coworker
+```
+RESUME COWORKER
+coworker_id: <id>
+```
+**Effect**
+- Coworker resumes responding to new threads.
+
+### 5) Update Role
+```
+UPDATE ROLE
+coworker_id: <id>
+role: <New Role Title>
+```
+**Notes**
+- Role updates do not change email aliases.
+
+---
+
+## Response Semantics (v0)
+- System replies in the same thread with one of:
+  - `OK` + a short summary of the action taken.
+  - `ERROR` + a short reason (e.g., `auth_failed`, `missing_field`, `unknown_coworker`).
+
+## Examples
+
+**Create org**
+```
+CREATE ORG
+name: Dopocorp
+admin_email: founder@dopocorp.com
+bootstrap_token: 9f2c-…
+```
+
+**Hire coworker**
+```
+HIRE COWORKER
+coworker_id: eng-1
+name: Alex Rivera
+role: Founding Engineer
+email_alias: alex@dopocorp.com
+model: gpt-5
+```
+
+**Pause coworker**
+```
+PAUSE COWORKER
+coworker_id: eng-1
+reason: on leave
+```
+
+**Resume coworker**
+```
+RESUME COWORKER
+coworker_id: eng-1
+```
+
+**Update role**
+```
+UPDATE ROLE
+coworker_id: eng-1
+role: Staff Engineer
+```

--- a/work/employee-01/tasks.md
+++ b/work/employee-01/tasks.md
@@ -3,3 +3,4 @@
 - [x] Read company context (northstar, principles, product, vision).
 - [x] Define minimum system boundary, core entities, and hello-world flow.
 - [x] Write deliverables to output/.
+- [x] Draft email command grammar v0 for org/coworker management.


### PR DESCRIPTION
### Motivation
- Define a minimal, email-only command surface to create organizations and manage AI coworkers consistent with the product principle that `email is the UI`.
- Keep the system boundary small (ingest → interpret → respond) and avoid UI or real-time dependencies for the MVP.
- Provide a simple, auditable bootstrap and sender validation approach to allow safe org creation without building an admin dashboard.
- Enable straightforward lifecycle operations (hire, pause, resume, update role) so the hello-world flow can be exercised end-to-end.

### Description
- Add `work/employee-01/output/email-command-spec.md` containing the v0 command grammar, examples, response semantics, transport, and bootstrap paths.
- Capture auth assumptions in `work/employee-01/decisions.md`, specifying an allowlist-first approach with an optional one-time bootstrap token for org creation.
- Update `work/employee-01/README.md` and `work/employee-01/tasks.md` to reflect the new deliverable and completed task for drafting the command spec.
- Commands are plain-text, one-per-email to a `control@` address and include `CREATE ORG`, `HIRE COWORKER`, `PAUSE COWORKER`, `RESUME COWORKER`, and `UPDATE ROLE` with `OK`/`ERROR` reply semantics.

### Testing
- No automated tests were run because these are specification-only changes.
- The change set is limited to documentation and task/decision tracking files under `work/employee-01`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f069bbed883209e7811080c7fe571)