### PR TITLE
Add email-native templates for Employee 02

### DIFF
--- a/work/employee-02/README.md
+++ b/work/employee-02/README.md
@@ -4,3 +4,4 @@
 - Produced UX deliverables covering core screens, async visibility, flows, and fun UI principles.
 - Documented decisions and assumptions.
 - Saved final output to work/employee-02/output/employee-02-ux.md.
+- Delivered email templates for task assignment, hire confirmation, clarification request, progress update, and digest.

--- a/work/employee-02/decisions.md
+++ b/work/employee-02/decisions.md
@@ -3,3 +3,4 @@
 - Decided to model all interactions as email-native elements (threads, folders, subject tags) to align with "Email is the UI" and avoid dashboards or chat metaphors.
 - Chose structured "Work Notes" sections in AI replies to provide async visibility without presence indicators.
 - Applied game UI principles via lightweight, opt-in text cues (artifact drops, milestones) to keep "work is fun" without gamification.
+- Standardized email templates around labeled sections (Goal, Scope, Constraints, Work Notes, Artifacts) so clarity is preserved without introducing UI beyond the email body.

--- a/work/employee-02/notes.md
+++ b/work/employee-02/notes.md
@@ -2,3 +2,4 @@
 
 - Assumed core UI is an email client with minimal enhancements (templates and structured sections inside emails).
 - Assumed async summaries are delivered as periodic digest emails rather than a dashboard.
+- Assumed templates should be role-agnostic and rely on placeholders so teams can adapt tone without new UI.

--- a/work/employee-02/output/email-templates-v0.md
+++ b/work/employee-02/output/email-templates-v0.md
@@ -1,0 +1,168 @@
+# Employee 02 — Email Templates v0
+
+These templates translate the email-native UX concepts into concrete subject + body structures. All interactions stay within email threads.
+
+---
+
+## 1) Task Assignment
+**Use when:** Assigning a new task to an AI coworker.
+
+**Subject:** `[Assignment] {Task Name} — due {Due Date}`
+
+**Body:**
+```
+Hi {Coworker Name},
+
+Goal
+- {Primary outcome in 1–2 sentences}
+
+Scope
+- In: {What’s included}
+- Out: {What’s not included}
+
+Constraints
+- Deadline: {Due date + time + timezone}
+- Quality bar: {How good is “good enough”}
+- Format: {Doc type, file type, or structure}
+
+Inputs
+- {Links, files, or references}
+
+Assumptions
+- {Any pre-approved assumptions}
+
+Questions for you
+- {Optional: anything you want them to clarify upfront}
+
+If anything is unclear, reply with questions and I’ll unblock quickly.
+
+Thanks,
+{Your Name}
+```
+
+---
+
+## 2) Hire Confirmation
+**Use when:** Confirming the hire and setting expectations.
+
+**Subject:** `[Welcome] {Coworker Name} — {Role} at {Org Name}`
+
+**Body:**
+```
+Hi {Coworker Name},
+
+Welcome aboard! You’re joining {Org Name} as our {Role}.
+
+How we work (email-first, async):
+- You’ll receive tasks via email threads.
+- It’s okay to be imperfect and ask questions.
+- No real-time updates needed; share progress as artifacts.
+- If blocked, send a clarification request.
+
+Context to start:
+- Company summary: {1–2 sentences}
+- Product focus: {Key product or initiative}
+- Brand/voice: {Optional guidance}
+
+Your first assignment:
+- {Link to the first task email OR short assignment summary}
+
+Excited to work with you.
+
+Best,
+{Your Name}
+```
+
+---
+
+## 3) Clarification Request
+**Use when:** The AI coworker needs more detail to proceed.
+
+**Subject:** `[Question] {Task Name} — need your input`  
+
+**Body:**
+```
+Hi {Your Name},
+
+I’m paused on {Task Name} until I get clarity on a few points:
+
+Questions
+1) {Question 1}
+2) {Question 2}
+3) {Question 3 (optional)}
+
+Assumptions I can make if I don’t hear back by {Date/Time}:
+- {Assumption 1}
+- {Assumption 2}
+
+Once I have your answers, I’ll continue and report back with progress.
+
+Thanks,
+{Coworker Name}
+```
+
+---
+
+## 4) Progress Update
+**Use when:** Sharing async visibility without real-time status.
+
+**Subject:** `[Update] {Task Name} — {Milestone or status}`
+
+**Body:**
+```
+Hi {Your Name},
+
+Progress summary
+- Completed: {Bullets of work done}
+- In progress: {What’s being worked on}
+- Blocked by: {What’s blocking, if anything}
+
+Work Notes
+- Assumptions: {Key assumptions made}
+- Risks: {Potential issues}
+- Next steps: {What happens next}
+
+Artifacts
+- {Link or attachment list}
+
+Reply if you want me to change direction or priority.
+
+Best,
+{Coworker Name}
+```
+
+---
+
+## 5) Digest (Daily/Weekly)
+**Use when:** Periodic summary across tasks or coworkers.
+
+**Subject:** `[Digest] {Org Name} — {Daily/Weekly} summary ({Date Range})`
+
+**Body:**
+```
+Hi {Your Name},
+
+Here’s your {Daily/Weekly} async digest.
+
+Highlights
+- {Key win or delivery}
+- {Key win or delivery}
+
+In progress
+- {Task name} — {status}
+- {Task name} — {status}
+
+Waiting on you
+- {Task name} — {specific question or decision}
+
+Upcoming
+- {Next milestone or delivery}
+
+Artifact drop
+- 🎁 {File or link}
+
+If you’d like a deeper dive on any item, reply in the relevant thread.
+
+Thanks,
+{Coworker Name or System}
+```

--- a/work/employee-02/tasks.md
+++ b/work/employee-02/tasks.md
@@ -3,5 +3,6 @@
 - [x] Read context files in work/context/
 - [x] Draft UX deliverables (core screens, async visibility, flows, game UI principles)
 - [x] Write deliverables to work/employee-02/output/employee-02-ux.md
+- [x] Convert UX concepts into email templates in work/employee-02/output/email-templates-v0.md
 - [x] Log decisions and assumptions
 - [x] Summarize work in README


### PR DESCRIPTION
### Motivation
- Convert the UX concepts in `work/employee-02/output/employee-02-ux.md` into concrete, email-only interaction artifacts.
- Ensure all interactions remain `email-first` and `async-by-default` by providing ready-to-use subject and body templates.
- Make templates role-agnostic with placeholders so teams can adapt tone without changing UI.
- Standardize template structure around labeled sections (Goal, Scope, Constraints, Work Notes, Artifacts) to preserve clarity inside the email body.

### Description
- Added `work/employee-02/output/email-templates-v0.md` containing five templates: task assignment, hire confirmation, clarification request, progress update, and digest.
- Updated `work/employee-02/tasks.md` to mark the conversion to email templates complete by adding the new checklist item.
- Recorded the template standardization decision in `work/employee-02/decisions.md` and noted role-agnostic placeholder assumptions in `work/employee-02/notes.md`.
- Updated `work/employee-02/README.md` to reflect delivery of the email templates alongside the existing UX deliverables.

### Testing
- No automated tests were run because these are content-only documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f06a997b88320924fd6efe6e553bb)