### PR TITLE
Add v0 acceptance checklist and red-line scope warnings for MVP

### DIFF
--- a/work/employee-05/README.md
+++ b/work/employee-05/README.md
@@ -3,3 +3,4 @@
 ## Summary
 - Read product context files and aligned scope guidance to email-only north star.
 - Delivered MVP feature list, anti-feature list, north-star violations, and a 2-week execution plan to work/employee-05/output/mvp-scope-police.md.
+- Added v0 acceptance checklist and red-line scope warnings to work/employee-05/output/v0-acceptance-checklist.md.

--- a/work/employee-05/output/v0-acceptance-checklist.md
+++ b/work/employee-05/output/v0-acceptance-checklist.md
@@ -1,0 +1,22 @@
+# v0 Acceptance Checklist (Strict Gate)
+
+## Must-Pass Checks
+- **Email-only interface**: All user and coworker interactions happen in email threads. No UI beyond bare signup/landing.
+- **Org setup by email**: Users can create/join an org via email and receive an org address.
+- **Hire by email**: Users can hire a coworker via email and receive the coworker’s email identity.
+- **Task assignment by thread**: Users can assign tasks to coworkers in a thread; coworker replies asynchronously.
+- **Thread-local memory only**: Coworkers reference only the active thread; no cross-thread knowledge.
+- **Deliberate delays**: Responses are delayed to enforce async behavior.
+- **Email audit trail**: Outputs are delivered as email replies/attachments only.
+- **Basic email admin commands**: Pause/resume or update role via email commands.
+- **Single model/provider**: One LLM backing all coworkers in v0.
+
+## Red-Line Scope Warnings (Auto-Reject)
+- **Any non-email primary UI** (dashboard, inbox clone, chat panel).
+- **Real-time presence/status** (typing indicators, online status, live updates).
+- **Chat or Slack/Teams metaphors**.
+- **Project management views** (Kanban, timelines, dashboards).
+- **Cross-thread memory, knowledge base, or global context**.
+- **Integrations** (GitHub, Notion, Calendar, Zapier) in v0.
+- **File collaboration suites** (Docs-style editing or shared workspaces).
+- **Multi-org management or billing complexity**.

--- a/work/employee-05/tasks.md
+++ b/work/employee-05/tasks.md
@@ -2,3 +2,4 @@
 
 - [x] Read context files in work/context/.
 - [x] Produce MVP scope guardrails and execution plan.
+- [x] Produce v0 acceptance checklist and red-line scope warnings.


### PR DESCRIPTION
### Motivation
- Enforce the email-only north star by providing a strict v0 gate for what can ship.
- Prevent scope creep by making acceptance criteria explicit and easy to apply to build decisions.
- Call out immediate auto-reject items (red-line warnings) that violate v0 constraints.

### Description
- Add `work/employee-05/output/v0-acceptance-checklist.md` with must-pass checks and red-line scope warnings.
- Update `work/employee-05/README.md` to reference the new checklist.
- Update `work/employee-05/tasks.md` to mark the checklist task complete.
- Commit the added and updated files to the repository.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f06b5ec24832084130f015d657ef2)