### PR TITLE
Add v0 org bootstrap and admin auth spec

### DIFF
--- a/work/employee-01/README.md
+++ b/work/employee-01/README.md
@@ -4,3 +4,4 @@
 - Produced a minimal system boundary spec, core entity list, and hello-world flow in output/.
 - Logged decisions and notes, and updated tasks.
 - Drafted v0 email command grammar for org/coworker management in output/.
+- Drafted the v0 org bootstrap and admin auth model for email commands in output/.

--- a/work/employee-01/decisions.md
+++ b/work/employee-01/decisions.md
@@ -2,3 +2,4 @@
 
 - Kept the system boundary limited to the email task loop (ingest → interpret → respond) to align with “email is the UI” and avoid feature creep.
 - For v0 email command auth, assumed allowlist-first with optional bootstrap token to avoid any UI-based setup.
+- Org creation is email-only, gated by sender allowlist or one-time bootstrap tokens tied to the admin email.

--- a/work/employee-01/output/org-bootstrap-auth.md
+++ b/work/employee-01/output/org-bootstrap-auth.md
@@ -1,0 +1,86 @@
+# v0 Org Bootstrap + Admin Auth Model (Email Commands)
+
+## Scope
+Email-only org creation and admin validation for v0. No UI or manual console paths.
+
+## Single Allowed Org Creation Path
+**Email-only bootstrap** via a system address (e.g., `create@dopocorp.com`).
+
+**Required email command (new thread):**
+```
+create org
+name: <org_name>
+admin_email: <admin_email>
+bootstrap_token: <token> (optional if sender is pre-allowed)
+```
+
+**Rules:**
+- Org creation **only** occurs from an inbound email command.
+- No manual back-office or UI bootstrap is permitted in v0.
+- `admin_email` becomes the initial admin and primary allowlisted sender.
+- Sender must pass validation (see below). Otherwise, the command is rejected.
+
+## Sender Validation Rules
+Validation occurs before any org record is created.
+
+1. **Normalize sender + fields**
+   - Lowercase `From` and `admin_email`.
+   - Strip display names; compare pure addresses only.
+
+2. **Hard allowlist check (highest trust)**
+   - If sender email is in the system allowlist, org creation is allowed **without** a bootstrap token.
+   - Use this for internal test accounts or pre-approved customers.
+
+3. **Domain check (moderate trust)**
+   - If sender is not explicitly allowlisted, the sender’s domain must match `admin_email` domain.
+   - If domains mismatch → reject.
+
+4. **Bootstrap token check (required if not allowlisted)**
+   - If sender is not on the allowlist, `bootstrap_token` is required.
+   - Token must be valid, unused, and tied to the `admin_email` (or domain).
+   - Tokens are one-time use and expire after a short window (e.g., 7 days).
+
+5. **Final admin_email match**
+   - Sender must equal `admin_email` after normalization.
+   - If not equal → reject (even if token is valid).
+
+## Error Responses & Edge Cases
+All failures respond in the same thread with a concise, email-only message.
+
+**Unknown sender (not allowlisted + no/invalid token):**
+- Response: “We couldn’t verify your sender address. Please request a bootstrap token or contact support.”
+
+**Domain mismatch:**
+- If sender domain differs from `admin_email` domain:
+  - Response: “Sender domain must match admin_email domain.”
+
+**Mismatched admin_email:**
+- If `From` ≠ `admin_email` after normalization:
+  - Response: “admin_email must match the sender address.”
+
+**Invalid or reused token:**
+- Response: “Bootstrap token is invalid or expired. Please request a new token.”
+
+**Org already exists:**
+- If org name already exists (case-insensitive):
+  - Response: “Organization name is already in use. Choose another name.”
+
+**Duplicate request in same thread:**
+- If a valid org was created already and a new create command appears:
+  - Response: “Organization already created for this thread.”
+
+**Missing required fields:**
+- If `name` or `admin_email` missing:
+  - Response: “Missing required fields: name, admin_email.”
+
+**Ambiguous sender (forwarded messages / multiple From headers):**
+- If multiple From headers or Resent-From present:
+  - Use the top-level `From`. If ambiguous, reject with:
+  - Response: “Unable to verify sender from forwarded email. Please resend from the intended admin address.”
+
+**Plus addressing:**
+- Treat `admin+tag@domain.com` as a distinct address (no stripping). Keep simple for v0.
+
+## Notes
+- All decisions are consistent with “email is the UI” and no real-time setup.
+- The allowlist + bootstrap token provides a minimal, auditable gate for org creation.

--- a/work/employee-01/tasks.md
+++ b/work/employee-01/tasks.md
@@ -4,3 +4,4 @@
 - [x] Define minimum system boundary, core entities, and hello-world flow.
 - [x] Write deliverables to output/.
 - [x] Draft email command grammar v0 for org/coworker management.
+- [x] Draft v0 org bootstrap + admin auth model for email commands.


### PR DESCRIPTION
### Motivation

- Provide a v0, email-only org creation and admin validation model so orgs can be bootstrapped without a UI.
- Enforce a minimal auth gate using a sender allowlist and one-time bootstrap tokens to prevent unauthorized org creation.
- Keep the design constrained to the email task loop and align with the product principle that `email` is the UI.

### Description

- Add `work/employee-01/output/org-bootstrap-auth.md` documenting the `create org` command, sender normalization, allowlist rules, domain checks, bootstrap token handling, error responses, and edge cases.
- Update `work/employee-01/tasks.md` to mark the org bootstrap/auth model task complete.
- Update `work/employee-01/decisions.md` to record that org creation is email-only and gated by allowlist or one-time tokens.
- Update `work/employee-01/README.md` to reflect the new deliverable in the employee summary.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0d32f6688320a571452a123cb387)