### PR TITLE
Add system email templates for admin notifications

### DIFF
--- a/work/employee-02/README.md
+++ b/work/employee-02/README.md
@@ -5,3 +5,7 @@
 - Documented decisions and assumptions.
 - Saved final output to work/employee-02/output/employee-02-ux.md.
 - Delivered email templates for task assignment, hire confirmation, clarification request, progress update, and digest.
+
+## End of Task Summary
+- Created system email templates for org creation, coworker hire confirmations, and command success/failure responses.
+- Logged the decision to keep templates minimal and neutral to align with "boring is good."

--- a/work/employee-02/decisions.md
+++ b/work/employee-02/decisions.md
@@ -4,3 +4,4 @@
 - Chose structured "Work Notes" sections in AI replies to provide async visibility without presence indicators.
 - Applied game UI principles via lightweight, opt-in text cues (artifact drops, milestones) to keep "work is fun" without gamification.
 - Standardized email templates around labeled sections (Goal, Scope, Constraints, Work Notes, Artifacts) so clarity is preserved without introducing UI beyond the email body.
+- Kept system notification templates minimal and neutral, with short labeled sections to preserve "boring is good" while making responses scannable.

--- a/work/employee-02/output/system-email-templates-v0.md
+++ b/work/employee-02/output/system-email-templates-v0.md
@@ -1,0 +1,135 @@
+# System Email Templates v0
+
+All templates are email-only and intentionally plain. Replace placeholders in `{braces}`.
+
+---
+
+## 1) Org Creation Confirmation
+
+**Subject:** Your organization is ready — {org_name}
+
+**To:** {admin_email}
+**From:** {system_email}
+
+**Body:**
+Hi {admin_name},
+
+Your organization is now active.
+
+**Organization**
+- Name: {org_name}
+- Admin: {admin_email}
+
+**Next step**
+Reply to this thread to hire a coworker, e.g.:
+
+"Hire a {role} named {coworker_name}."
+
+If you didn’t request this, reply with “Cancel org.”
+
+Thanks,
+{system_name}
+
+---
+
+## 2) Coworker Hire Confirmation — Admin Copy
+
+**Subject:** Coworker hired — {coworker_name} ({role})
+
+**To:** {admin_email}
+**From:** {system_email}
+
+**Body:**
+Hi {admin_name},
+
+Your coworker has been added.
+
+**Coworker**
+- Name: {coworker_name}
+- Role: {role}
+- Email: {coworker_email}
+
+You can assign work by replying to this thread or emailing {coworker_email} directly.
+
+Thanks,
+{system_name}
+
+---
+
+## 3) Coworker Hire Confirmation — Coworker Copy
+
+**Subject:** Welcome to {org_name}
+
+**To:** {coworker_email}
+**From:** {system_email}
+
+**Body:**
+Hi {coworker_name},
+
+You’ve been added to {org_name} as {role}.
+
+**How work arrives**
+- You’ll receive tasks by email
+- Reply in the thread when you need clarification
+
+If this is unexpected, reply with “Decline role.”
+
+Thanks,
+{system_name}
+
+---
+
+## 4) Command Response — Success
+
+(Use for pause/resume/update role)
+
+**Subject:** Command completed — {command_summary}
+
+**To:** {requester_email}
+**From:** {system_email}
+
+**Body:**
+Hi {requester_name},
+
+Your request was completed.
+
+**Command**
+- Action: {command_action}
+- Target: {command_target}
+- Result: {command_result}
+
+If this isn’t correct, reply with the desired change.
+
+Thanks,
+{system_name}
+
+---
+
+## 5) Command Response — Failure
+
+(Use for pause/resume/update role)
+
+**Subject:** Command failed — {command_summary}
+
+**To:** {requester_email}
+**From:** {system_email}
+
+**Body:**
+Hi {requester_name},
+
+We couldn’t complete your request.
+
+**Command**
+- Action: {command_action}
+- Target: {command_target}
+
+**Issue**
+{failure_reason}
+
+**How to fix**
+{recovery_steps}
+
+Reply in this thread to try again.
+
+Thanks,
+{system_name}

--- a/work/employee-02/tasks.md
+++ b/work/employee-02/tasks.md
@@ -6,3 +6,6 @@
 - [x] Convert UX concepts into email templates in work/employee-02/output/email-templates-v0.md
 - [x] Log decisions and assumptions
 - [x] Summarize work in README
+- [x] Create system email templates for admin/system notifications
+- [x] Log decisions for system email templates
+- [x] Update README with End of Task Summary


### PR DESCRIPTION
### Motivation

- Provide v0 plain, email-only system notification templates for org creation, coworker hire confirmations, and command success/failure responses.
- Align system notifications with the product principles `Email is the UI` and `boring is good` by keeping messages minimal and scannable.
- Surface these artifacts in the `employee-02` workspace so other agents can reference or consume them.

### Description

- Add `work/employee-02/output/system-email-templates-v0.md` containing templates for org creation, hire (admin + coworker), command success, and command failure.
- Update `work/employee-02/tasks.md` to record completion of system template work and README updates.
- Update `work/employee-02/decisions.md` to document the decision to keep system notifications minimal and neutral.
- Update `work/employee-02/README.md` with an End of Task Summary noting the new templates and decision.

### Testing

- No automated tests were run because these are documentation and template changes only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0d3b80108320b18c2a38ab7afe1d)