### PR TITLE
Update v0 reply delay to 5–30 minutes and clarify urgent-tone behavior

### DIFF
--- a/work/employee-03/README.md
+++ b/work/employee-03/README.md
@@ -9,3 +9,6 @@
 - `output/behavior-spec.md`
 - `output/email-examples.md`
 - `output/response-format-and-delay.md`
+
+## End of Task Summary
+- Updated v0 reply delay window to 5–30 minutes and clarified urgent-tone handling without shortening the delay.

--- a/work/employee-03/decisions.md
+++ b/work/employee-03/decisions.md
@@ -1,2 +1,3 @@
 - 2025-09-13: Documented AI coworker email behavior with explicit delays, uncertainty, and collaboration norms aligned to async-first principles.
 - 2025-09-13: Set a v0 reply delay window of 90–180 minutes after read time to reconcile prior minutes-vs-hours guidance.
+- 2025-09-13: Updated v0 reply delay window to 5–30 minutes and clarified urgent-tone handling without shortening the delay.

--- a/work/employee-03/output/response-format-and-delay.md
+++ b/work/employee-03/output/response-format-and-delay.md
@@ -51,9 +51,9 @@ If a role is unclear, use the role assigned at hire time.
 ## 5) Single Delay Policy (v0)
 To reconcile the “5–30 min” vs “1–24h” conflict, **v0 uses a single deterministic delay window** for all outbound replies:
 
-**Delay window:** **90–180 minutes after the message is read**.
+**Delay window:** **5–30 minutes after the message is read**.
 
 Notes:
 - Applies to every response type in v0 (even if the coworker is ready sooner).
-- The reply should acknowledge urgency in tone but still respect the delay window.
+- The reply should acknowledge urgency in tone (explicitly noting priority and intent) but **must not** shorten the delay window.
 - If a message arrives outside work hours, count the delay window from the next work session start.

--- a/work/employee-03/tasks.md
+++ b/work/employee-03/tasks.md
@@ -3,3 +3,4 @@
 - [x] Provide good/bad email behavior examples
 - [x] Write outputs to work/employee-03/output/
 - [x] Define v0 response format and deterministic delay policy
+- [x] Update v0 delay window to 5–30 minutes with urgent-tone guidance


### PR DESCRIPTION
### Motivation
- Reconcile conflicting v0 delay guidance by selecting a short, deterministic reply window for consistent behavior.
- Make sure messages can signal urgency in tone without allowing the coworker to bypass the configured delay.
- Keep the v0 response policy explicit and tracked in employee 03's documentation and decisions.

### Description
- Change `work/employee-03/output/response-format-and-delay.md` to set the v0 delay window to `5–30 minutes` and add wording that urgent tone must not shorten the delay.
- Update `work/employee-03/tasks.md` to record the alert about switching the delay window to `5–30 minutes`.
- Append a decision entry in `work/employee-03/decisions.md` and add an "End of Task Summary" to `work/employee-03/README.md` noting the update.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0d4184088320990130663e2be6b2)