### PR TITLE
Add PM cycle-1 outputs and set cycle-2 demo objective

### DIFF
--- a/work/employee-pm/output/cycle-1-review.md
+++ b/work/employee-pm/output/cycle-1-review.md
@@ -1,0 +1,25 @@
+# Cycle 1 Review (Employee PM)
+
+## Employee 01 — Founding Engineer
+**Status:** ACCEPT
+**Why:** Command grammar and bootstrap/auth model are concrete, email-only, and aligned to MVP constraints.
+
+## Employee 02 — Product Designer
+**Status:** ACCEPT
+**Why:** Email templates and UX framing remain strictly email-native and support async visibility without UI creep.
+
+## Employee 03 — AI Coworker Behavior Lead
+**Status:** ACCEPT
+**Why:** Response format is clear, delay policy is aligned to 5–30 minutes, and tone guidance fits the “imperfect coworker” principle.
+
+## Employee 04 — Email System Engineer
+**Status:** ACCEPT
+**Why:** Threading model and pipeline/runtime components are cohesive and implementable for v0.
+
+## Employee 05 — MVP Scope Police
+**Status:** ACCEPT
+**Why:** MVP guardrails and QA scenarios are crisp and enforce the email-only demo target.
+
+## Employee Onboarding
+**Status:** ACCEPT
+**Why:** Onboarding workspace is complete; no additional deliverables required this cycle.

--- a/work/employee-pm/output/cycle-1-synthesis.md
+++ b/work/employee-pm/output/cycle-1-synthesis.md
@@ -1,0 +1,21 @@
+# Cycle 1 Synthesis (Employee PM)
+
+## What is DONE
+- Core product context and constraints are established (email-only, async, no chat/UI).
+- Org/coworker command grammar and bootstrap/auth model are defined for v0.
+- AI coworker behavior, response format, and delay policy are specified (5–30 minutes).
+- Email threading model, pipeline spec, and runtime components are documented.
+- UX/email templates and QA scenarios for v0 acceptance are delivered.
+
+## What is PARTIALLY DONE
+- Demo execution path is defined on paper but not implemented in a runnable system.
+- Email transport choice is specified in principle (single SMTP provider) but not selected or wired.
+
+## What is BLOCKED
+- None strictly blocked, but demo execution depends on selecting a transport (or mock) and wiring a minimal runtime.
+
+## What is MISSING for demo
+- Runnable demo implementation (even mocked) that executes: create org → hire coworker → send email → delayed coworker reply.
+- Minimal storage/runtime (in-memory or simple DB) to store orgs, coworkers, threads, messages.
+- A working ingress/egress path for emails (mock inbox/outbox acceptable).
+- A deterministic delay scheduler to simulate 5–30 minute response behavior in demo time.

--- a/work/employee-pm/output/cycle-2-demo-status.md
+++ b/work/employee-pm/output/cycle-2-demo-status.md
@@ -1,0 +1,5 @@
+# Cycle 2 Demo Status
+
+- **Is the demo more real after this cycle?** No — this cycle defines the work needed to make it runnable.
+- **What exactly will be demoable?** Once tasks complete, a mocked end-to-end email loop (create org → hire coworker → send task email → delayed coworker reply) using in-memory storage and a simulated email transport.
+- **Biggest remaining risk:** Implementing a runnable loop without picking a real email provider; if mocking is insufficient for stakeholders, we may need a quick transport decision.

--- a/work/employee-pm/output/cycle-2-objective.md
+++ b/work/employee-pm/output/cycle-2-objective.md
@@ -1,0 +1,3 @@
+# Cycle 2 Objective
+
+Build a runnable demo path that executes the end-to-end email loop (create org → hire coworker → send task email → delayed coworker reply) using a mocked email transport and minimal in-memory storage.

--- a/work/employee-pm/output/cycle-2-prompts.md
+++ b/work/employee-pm/output/cycle-2-prompts.md
@@ -1,0 +1,17 @@
+Employee 01 — Founding Engineer
+Implement (or stub) a runnable demo loop using mocked email transport and in-memory storage. The demo must cover: create org → hire coworker → send task email → schedule delayed reply → send reply in same thread. Output a short implementation note and how-to-run steps to `work/employee-01/output/demo-implementation-notes.md`.
+
+Employee 02 — Product Designer
+Provide a ready-to-use set of demo emails (subjects + bodies) for org creation, coworker hire, task assignment, and the coworker reply formatted per v0 templates. Output to `work/employee-02/output/demo-email-scripts.md`.
+
+Employee 03 — AI Coworker Behavior Lead
+Write a concrete coworker reply prompt template that produces the required response format (subject prefix + Work Notes + signature) for the demo. Include a sample filled-out reply for the demo task email. Output to `work/employee-03/output/demo-reply-prompt.md`.
+
+Employee 04 — Email System Engineer
+Define a minimal mocked email transport + scheduler design for the demo (in-memory queue, delay timer, thread linkage). Include required payload fields and suggested local dev wiring. Output to `work/employee-04/output/demo-mock-transport.md`.
+
+Employee 05 — MVP Scope Police
+Write a demo acceptance checklist tailored to the mocked transport path, including explicit pass/fail criteria and any red-line scope violations to avoid. Output to `work/employee-05/output/demo-acceptance-checklist.md`.
+
+Employee onboarding — Onboarding
+Verify that each employee folder has the new demo-related output file requested this cycle and list any gaps. Output to `work/employee-onboarding/output/cycle-2-folder-audit.md`.

--- a/work/state.md
+++ b/work/state.md
@@ -6,3 +6,4 @@
 2025-12-26: Prototype status updated: closer to runnable demo; key risks are unresolved org bootstrap/auth and delay window decisions plus email transport choice.
 2025-12-26: Employee PM refined review status: Employee 03 marked blocked pending founder decision on reply delay window; prototype risk/milestone notes updated accordingly.
 2025-12-26: Employee PM resolved the v0 reply delay window decision to 5–30 minutes, unblocking behavior-spec revision tasks.
+2025-12-26: Employee PM completed cycle 1 synthesis/review, set cycle 2 objective to build a runnable mocked email demo, and assigned demo-focused tasks to all employees.


### PR DESCRIPTION
### Motivation
- Capture the Product Manager's cycle-1 synthesis and review artifacts to record decisions and unblock work for the demo.
- Make an explicit cycle-2 objective to build a runnable mocked email demo (create org → hire coworker → task email → delayed reply).
- Assign concrete demo-focused tasks to each employee to move from design/spec to an executable prototype.

### Description
- Added PM artifacts `work/employee-pm/output/cycle-1-synthesis.md` and `work/employee-pm/output/cycle-1-review.md` documenting what is done, gaps, and accept/revise statuses.
- Added cycle planning files `work/employee-pm/output/cycle-2-objective.md`, `work/employee-pm/output/cycle-2-prompts.md`, and `work/employee-pm/output/cycle-2-demo-status.md` with the demo objective and per-employee prompts.
- Appended a state log entry in `work/state.md` to record the cycle completion and next steps.
- These are documentation-only changes to drive next cycle work and do not modify runtime code or tests.

### Testing
- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0fa78da083208efbb7b81d37fdca)