### PR TITLE
Add runnable mocked email demo loop for cycle 2

### DIFF
--- a/work/employee-01/README.md
+++ b/work/employee-01/README.md
@@ -5,3 +5,4 @@
 - Logged decisions and notes, and updated tasks.
 - Drafted v0 email command grammar for org/coworker management in output/.
 - Drafted the v0 org bootstrap and admin auth model for email commands in output/.
+- Implemented a runnable mocked email demo loop and wrote implementation notes in output/.

--- a/work/employee-01/decisions.md
+++ b/work/employee-01/decisions.md
@@ -3,3 +3,5 @@
 - Kept the system boundary limited to the email task loop (ingest → interpret → respond) to align with “email is the UI” and avoid feature creep.
 - For v0 email command auth, assumed allowlist-first with optional bootstrap token to avoid any UI-based setup.
 - Org creation is email-only, gated by sender allowlist or one-time bootstrap tokens tied to the admin email.
+- Implemented the demo loop as a self-contained Python script inside the employee output folder to avoid writing outside `work/` while still being runnable.
+- Used a simple sleep-based scheduler to model delayed replies without external dependencies.

--- a/work/employee-01/output/demo-implementation-notes.md
+++ b/work/employee-01/output/demo-implementation-notes.md
@@ -1,0 +1,20 @@
+# Demo Implementation Notes (Employee 01)
+
+## What this covers
+- Create org → hire coworker → send task email → schedule delayed reply → send reply in same thread.
+- Uses a mocked email transport and in-memory storage only.
+- Scheduler is a simple in-process delay queue to simulate async reply.
+
+## Files
+- `work/employee-01/output/demo_loop.py`
+
+## How to run
+```bash
+python work/employee-01/output/demo_loop.py
+```
+
+Expected output includes:
+- Logs for org creation and coworker hire
+- A task email sent on `thread-1001`
+- A delayed reply in the same thread
+- A printed transcript of the thread

--- a/work/employee-01/output/demo_loop.py
+++ b/work/employee-01/output/demo_loop.py
@@ -1,0 +1,141 @@
+"""Runnable mocked email demo loop for cycle 2."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+
+@dataclass
+class Thread:
+    thread_id: str
+    messages: List[Dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class InMemoryStore:
+    orgs: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    coworkers: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    threads: Dict[str, Thread] = field(default_factory=dict)
+
+    def create_org(self, org_id: str, name: str, admin_email: str) -> None:
+        self.orgs[org_id] = {
+            "org_id": org_id,
+            "name": name,
+            "admin_email": admin_email,
+        }
+
+    def hire_coworker(self, coworker_id: str, name: str, role: str, email: str) -> None:
+        self.coworkers[coworker_id] = {
+            "coworker_id": coworker_id,
+            "name": name,
+            "role": role,
+            "email": email,
+        }
+
+    def create_thread(self, thread_id: str) -> Thread:
+        thread = Thread(thread_id=thread_id)
+        self.threads[thread_id] = thread
+        return thread
+
+
+@dataclass
+class MockEmailTransport:
+    store: InMemoryStore
+
+    def send_email(
+        self,
+        *,
+        from_addr: str,
+        to_addr: str,
+        subject: str,
+        body: str,
+        thread_id: str,
+    ) -> None:
+        if thread_id not in self.store.threads:
+            self.store.create_thread(thread_id)
+        message = {
+            "from": from_addr,
+            "to": to_addr,
+            "subject": subject,
+            "body": body,
+            "thread_id": thread_id,
+        }
+        self.store.threads[thread_id].messages.append(message)
+        print(f"[send] {from_addr} -> {to_addr} | {subject} | thread={thread_id}")
+
+
+@dataclass
+class Scheduler:
+    queue: List[Dict[str, object]] = field(default_factory=list)
+
+    def schedule(self, delay_seconds: float, task: Callable[[], None]) -> None:
+        self.queue.append({"delay": delay_seconds, "task": task})
+
+    def run(self) -> None:
+        for job in self.queue:
+            delay = float(job["delay"])
+            task = job["task"]
+            print(f"[scheduler] waiting {delay:.1f}s")
+            time.sleep(delay)
+            task()
+        self.queue.clear()
+
+
+def demo() -> None:
+    store = InMemoryStore()
+    transport = MockEmailTransport(store=store)
+    scheduler = Scheduler()
+
+    org_id = "org-acme"
+    admin_email = "admin@acme.test"
+    coworker_id = "cw-01"
+    coworker_email = "sam@acme.test"
+    thread_id = "thread-1001"
+
+    print("[demo] create org")
+    store.create_org(org_id, "Acme", admin_email)
+
+    print("[demo] hire coworker")
+    store.hire_coworker(coworker_id, "Sam", "Engineer", coworker_email)
+
+    print("[demo] send task email")
+    transport.send_email(
+        from_addr=admin_email,
+        to_addr=coworker_email,
+        subject="Task: Draft onboarding email flow",
+        body=(
+            "Please draft the onboarding email flow for new orgs. "
+            "Include subject + body for the first message."
+        ),
+        thread_id=thread_id,
+    )
+
+    def send_delayed_reply() -> None:
+        transport.send_email(
+            from_addr=coworker_email,
+            to_addr=admin_email,
+            subject="Re: Task: Draft onboarding email flow",
+            body=(
+                "Work Notes:\n"
+                "- Proposed subject: Welcome to Acme (Getting Started)\n"
+                "- Body: Thanks for joining... (steps 1-3)\n\n"
+                "- Sam"
+            ),
+            thread_id=thread_id,
+        )
+
+    print("[demo] schedule delayed reply")
+    scheduler.schedule(1.5, send_delayed_reply)
+    scheduler.run()
+
+    print("[demo] thread transcript")
+    for message in store.threads[thread_id].messages:
+        print(
+            f"  - {message['from']} -> {message['to']} | {message['subject']}"
+        )
+
+
+if __name__ == "__main__":
+    demo()

--- a/work/employee-01/tasks.md
+++ b/work/employee-01/tasks.md
@@ -5,3 +5,4 @@
 - [x] Write deliverables to output/.
 - [x] Draft email command grammar v0 for org/coworker management.
 - [x] Draft v0 org bootstrap + admin auth model for email commands.
+- [x] Implement a runnable mocked email demo loop and write implementation notes.


### PR DESCRIPTION
### Motivation
- Deliver a minimal, runnable demo that exercises the email task loop: create org → hire coworker → send task email → schedule delayed reply → send reply in the same thread.
- Keep the demo self-contained and restricted to `work/` with no external dependencies to follow the agent workspace rules.
- Provide clear implementation notes and run instructions for other employees to reproduce the demo locally.

### Description
- Add `work/employee-01/output/demo_loop.py` implementing an in-memory store, `MockEmailTransport`, and a simple sleep-based `Scheduler` to simulate delayed replies.
- Add `work/employee-01/output/demo-implementation-notes.md` with a summary of coverage and `python work/employee-01/output/demo_loop.py` run instructions.
- Update `work/employee-01/tasks.md`, `work/employee-01/decisions.md`, and `work/employee-01/README.md` to reflect the new demo work and design decisions.

### Testing
- No automated tests were added or executed for this change.
- The demo is designed to be runnable locally with `python work/employee-01/output/demo_loop.py` but the script was not executed as part of this rollout.
- Repository changes were committed successfully to the local git history.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f111dc5d8832084d9546c396285ba)