### PR TITLE
Add demo email scripts for cycle 2

### DIFF
--- a/work/employee-02/README.md
+++ b/work/employee-02/README.md
@@ -9,3 +9,4 @@
 ## End of Task Summary
 - Created system email templates for org creation, coworker hire confirmations, and command success/failure responses.
 - Logged the decision to keep templates minimal and neutral to align with "boring is good."
+- Delivered demo-ready email scripts covering org creation, coworker hire, task assignment, and coworker reply.

--- a/work/employee-02/decisions.md
+++ b/work/employee-02/decisions.md
@@ -5,3 +5,4 @@
 - Applied game UI principles via lightweight, opt-in text cues (artifact drops, milestones) to keep "work is fun" without gamification.
 - Standardized email templates around labeled sections (Goal, Scope, Constraints, Work Notes, Artifacts) so clarity is preserved without introducing UI beyond the email body.
 - Kept system notification templates minimal and neutral, with short labeled sections to preserve "boring is good" while making responses scannable.
+- Chose a minimal four-email demo script (org creation, hire confirmation, task assignment, coworker reply) with labeled sections to match v0 template format and keep tone neutral.

--- a/work/employee-02/output/demo-email-scripts.md
+++ b/work/employee-02/output/demo-email-scripts.md
@@ -1,0 +1,122 @@
+# Demo Email Scripts (Cycle 2)
+
+Below are ready-to-use demo emails (subject + body) for the mocked flow:
+Create org → Hire coworker → Assign task → Coworker reply.
+
+---
+
+## 1) Org Creation
+**Subject:** [System] Organization created: Dopoco Labs
+
+**Body:**
+Hello,
+
+Your organization has been created.
+
+**Organization**
+- Name: Dopoco Labs
+- Owner: alex@dopoco.com
+
+**Next Steps**
+- Hire a coworker by replying with a role and name.
+
+— Dopoco System
+
+---
+
+## 2) Coworker Hire Confirmation
+**Subject:** [System] Coworker hired: “Jamie Park” (Product Designer)
+
+**Body:**
+Hello,
+
+Your coworker has been added.
+
+**Coworker**
+- Name: Jamie Park
+- Role: Product Designer
+- Email: jamie@dopoco.com
+
+**Next Steps**
+- Assign a task by replying in this thread.
+
+— Dopoco System
+
+---
+
+## 3) Task Assignment Email
+**Subject:** [Task] Draft onboarding email series for new orgs
+
+**Body:**
+Hi Jamie,
+
+Please draft a short onboarding email series for new organizations.
+
+**Goal**
+- Provide a 3-email sequence for newly created orgs.
+
+**Scope**
+- 3 emails total
+- Plain text only
+- Each email ≤ 120 words
+
+**Constraints**
+- No marketing hype
+- Keep tone neutral and practical
+
+**Work Notes**
+- The product is email-first and async by default.
+- Avoid chat metaphors.
+
+Thanks,
+Alex
+
+---
+
+## 4) Coworker Reply (Formatted per v0 Templates)
+**Subject:** Re: [Task] Draft onboarding email series for new orgs
+
+**Body:**
+Hi Alex,
+
+Here’s a draft of the 3-email onboarding sequence.
+
+**Work Notes**
+- Kept each message short and practical.
+- Avoided marketing language and chat metaphors.
+- Included one clear action per email.
+
+**Artifacts**
+**Email 1 — Welcome & setup**
+Subject: Welcome to Dopoco Labs
+Body:
+Welcome to Dopoco Labs.
+
+Your org is ready. To start, reply with the role and name of the first coworker you want to hire.
+
+If you already know the first task, you can include it in the same reply.
+
+— Dopoco System
+
+**Email 2 — First task prompt**
+Subject: Your first task
+Body:
+You can assign work by replying in any thread.
+
+Send a short goal, scope, and constraints. The coworker will reply asynchronously in the same thread.
+
+— Dopoco System
+
+**Email 3 — Async expectations**
+Subject: How replies work
+Body:
+Coworkers respond in the same email thread. There are no real-time updates.
+
+If something is unclear, they will ask follow-up questions before proceeding.
+
+— Dopoco System
+
+**Questions**
+- Do you want these emails signed as “Dopoco System” or “Dopoco Team”? If not specified, I’ll keep “Dopoco System.”
+
+— Jamie

--- a/work/employee-02/tasks.md
+++ b/work/employee-02/tasks.md
@@ -9,3 +9,4 @@
 - [x] Create system email templates for admin/system notifications
 - [x] Log decisions for system email templates
 - [x] Update README with End of Task Summary
+- [x] Provide demo email scripts for org creation, coworker hire, task assignment, and coworker reply


### PR DESCRIPTION
### Motivation
- Provide ready-to-use demo emails to exercise the mocked flow: create org → hire coworker → assign task → coworker reply per cycle-2 prompts.
- Keep the demo content aligned with the v0 email template conventions (labeled sections like `Work Notes` and `Artifacts`).
- Surface a minimal, neutral tone consistent with the product principle “boring is good.”
- Mark the demo-related task as complete in the employee task list.

### Description
- Added `work/employee-02/output/demo-email-scripts.md` containing four demo-ready emails (org creation, hire confirmation, task assignment, coworker reply). 
- Updated `work/employee-02/decisions.md` to record the decision to use a minimal four-email demo script. 
- Updated `work/employee-02/tasks.md` to mark the demo email scripts task complete. 
- Updated `work/employee-02/README.md` End of Task Summary to note delivery of demo-ready scripts.

### Testing
- No automated tests were run for these content changes.
- Changes were staged and committed to the repository as a content update.
- Manual review of the added `demo-email-scripts.md` file was performed during the rollout.
- No runtime or integration checks were executed for the mocked demo flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f112368908320892b4e118e4a66a0)