### PR TITLE
Add demo coworker reply prompt and update employee-03 docs

### DIFF
--- a/work/employee-03/README.md
+++ b/work/employee-03/README.md
@@ -4,11 +4,13 @@
 - Produced an internal policy spec for AI coworker email behavior.
 - Provided good/bad email behavior examples for reference.
 - Defined a v0 response format and unified delay policy.
+- Drafted a demo-ready coworker reply prompt template with a filled-out sample.
 
 ## Outputs
 - `output/behavior-spec.md`
 - `output/email-examples.md`
 - `output/response-format-and-delay.md`
+- `output/demo-reply-prompt.md`
 
 ## End of Task Summary
-- Updated v0 reply delay window to 5–30 minutes and clarified urgent-tone handling without shortening the delay.
+- Created a concrete prompt template and example reply for the demo, enforcing the v0 subject prefixes, Work Notes fields, and signature format.

--- a/work/employee-03/decisions.md
+++ b/work/employee-03/decisions.md
@@ -1,3 +1,4 @@
 - 2025-09-13: Documented AI coworker email behavior with explicit delays, uncertainty, and collaboration norms aligned to async-first principles.
 - 2025-09-13: Set a v0 reply delay window of 90–180 minutes after read time to reconcile prior minutes-vs-hours guidance.
 - 2025-09-13: Updated v0 reply delay window to 5–30 minutes and clarified urgent-tone handling without shortening the delay.
+- 2025-09-13: Added a concrete demo reply prompt template with a filled-out example to enforce the v0 response format.

--- a/work/employee-03/output/demo-reply-prompt.md
+++ b/work/employee-03/output/demo-reply-prompt.md
@@ -1,0 +1,77 @@
+# Demo Coworker Reply Prompt (v0)
+
+Use this template to generate a coworker reply that **strictly** follows the v0 response format:
+- Subject must be prefixed with one of: **[Action] [Update] [Question] [Blocked] [FYI]**
+- Body must include an opening line, main response, and **Work Notes** section with required fields
+- End with the signature: `— <First Name>\n<Role> (AI Coworker)`
+
+---
+
+## Prompt Template
+
+**System / Instruction Prompt**
+
+```
+You are an AI coworker replying by email. Follow the required v0 email format exactly.
+
+Required format:
+1) Subject line must begin with one prefix: [Action], [Update], [Question], [Blocked], or [FYI].
+2) Body must include:
+   - Opening line (1–2 sentences)
+   - Main response (2–6 sentences)
+   - "Work Notes" section with fields:
+     - Status:
+     - Assumptions:
+     - Blockers:
+     - Next Step:
+     - ETA:
+3) Tone: brief, human, mild hedging, no overconfidence.
+4) End with signature:
+   — {first_name}
+   {role} (AI Coworker)
+
+Only output the email reply (subject + body). Do not add extra commentary.
+```
+
+**Input Variables**
+
+```
+{first_name} = "Maya"
+{role} = "PM"
+{original_subject} = "Task: Draft a welcome email for new orgs"
+{thread_context} = "Founder asked for a short welcome email draft for new orgs. Needs a version by Friday; wants it to feel human and not salesy."
+{request_details} = "Deliver a 4–6 sentence welcome email draft. If unclear, ask about brand tone and target persona."
+```
+
+**Output Instructions**
+
+```
+- Choose the correct subject prefix.
+- Subject must be: "[Prefix] Re: {original_subject}"
+- Body must follow the required format and include Work Notes.
+```
+
+---
+
+## Sample Filled-Out Reply (for the demo task email)
+
+**Subject:**
+```
+[Question] Re: Task: Draft a welcome email for new orgs
+```
+
+**Body:**
+```
+Quick skim — I can draft this, but I might be missing a bit of brand context.
+I’ll put together a short welcome email that feels friendly and low-pressure. Before I lock it, can you confirm the target persona (founder vs. ops) and whether we should sound more playful or professional? If I don’t hear back, I’ll default to a neutral, warm tone and send a draft tomorrow morning.
+
+Work Notes
+- Status: In progress
+- Assumptions: Neutral, warm tone; audience is a first-time founder
+- Blockers: Brand tone guidance
+- Next Step: Draft 4–6 sentence welcome email and send for review
+- ETA: tomorrow morning
+
+— Maya
+PM (AI Coworker)
+```

--- a/work/employee-03/tasks.md
+++ b/work/employee-03/tasks.md
@@ -4,3 +4,4 @@
 - [x] Write outputs to work/employee-03/output/
 - [x] Define v0 response format and deterministic delay policy
 - [x] Update v0 delay window to 5–30 minutes with urgent-tone guidance
+- [x] Write demo coworker reply prompt template with sample reply for cycle 2


### PR DESCRIPTION
### Motivation
- Provide a concrete, demo-ready prompt that enforces the v0 email response format for the cycle-2 demo requirements.
- Ensure the demo AI reply follows required `Subject` prefixes, the `Work Notes` fields, and signature conventions so other demo components can integrate deterministically.
- Record the change in the employee's local tasking and decision logs to maintain traceable agent memory.

### Description
- Add `work/employee-03/output/demo-reply-prompt.md`, a prompt template with `Input Variables`, `Output Instructions`, and a sample filled-out reply that matches the v0 format exactly.
- Update `work/employee-03/tasks.md` to mark the demo prompt task as completed and reflect the new deliverable.
- Append a decision entry in `work/employee-03/decisions.md` noting the addition of the demo reply prompt and update `work/employee-03/README.md` to list the new output and summary.

### Testing
- No automated tests were executed for these documentation and prompt-template changes.
- Validation consisted of file creation and local commits which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1128b2c08320a1c80acfea4a5215)