### PR TITLE
Add demo acceptance checklist for mocked email transport

### DIFF
--- a/work/employee-05/README.md
+++ b/work/employee-05/README.md
@@ -5,3 +5,4 @@
 - Delivered MVP feature list, anti-feature list, north-star violations, and a 2-week execution plan to work/employee-05/output/mvp-scope-police.md.
 - Added v0 acceptance checklist and red-line scope warnings to work/employee-05/output/v0-acceptance-checklist.md.
 - Translated v0 acceptance checklist into QA scenarios in work/employee-05/output/v0-qa-scenarios.md.
+- Added a demo acceptance checklist for the mocked transport path in work/employee-05/output/demo-acceptance-checklist.md.

--- a/work/employee-05/decisions.md
+++ b/work/employee-05/decisions.md
@@ -3,3 +3,4 @@
 - Prioritized an email-only MVP with minimal organization setup and tasking to uphold the "email is the UI" north star.
 - Explicitly banned any real-time UI, dashboards, and non-email integrations to prevent scope creep.
 - Interpreted the single model/provider check as verifying consistent model/provider identifiers across coworker responses when metadata is available.
+- Defined demo acceptance criteria that require mocked transport, in-memory storage, explicit delay scheduling, and thread-linked replies to protect the email-only loop.

--- a/work/employee-05/output/demo-acceptance-checklist.md
+++ b/work/employee-05/output/demo-acceptance-checklist.md
@@ -1,0 +1,58 @@
+# Demo Acceptance Checklist (Mocked Transport Path)
+
+## Scope
+This checklist validates the runnable demo that uses mocked email transport, in-memory storage, and a delay scheduler. It ensures the full loop works end-to-end: create org → hire coworker → send task email → schedule delayed reply → send reply in same thread.
+
+## Acceptance Checklist (Pass/Fail)
+
+### 1) Organization Creation (Email-Initiated)
+- **Pass**: Demo accepts a single email command that creates an org and produces a confirmation email reply.
+- **Fail**: Org creation requires UI clicks, dashboards, or out-of-band APIs.
+
+### 2) Coworker Hire (Email-Initiated)
+- **Pass**: Demo accepts a hire coworker email and returns a confirmation reply that includes coworker name + role.
+- **Fail**: Coworker is created via config file edits or web UI only.
+
+### 3) Task Assignment Email (Threaded)
+- **Pass**: A task email to the coworker is accepted and stored with a thread identifier.
+- **Fail**: Task assignment is handled outside an email thread or without thread linkage.
+
+### 4) Delayed Reply Scheduling
+- **Pass**: The system schedules a reply with a non-zero delay (simulated timer or queued job) and logs/surfaces the scheduled time.
+- **Fail**: Reply is sent immediately or delay is skipped.
+
+### 5) Reply Sent in Same Thread
+- **Pass**: The coworker reply is sent with the same thread identifier and references the original subject (e.g., “Re: …”).
+- **Fail**: Reply is sent as a new thread or lacks subject continuity.
+
+### 6) Required Reply Format (Demo Format)
+- **Pass**: Reply includes subject prefix + “Work Notes” section + coworker signature (per demo prompt template).
+- **Fail**: Reply omits the required format or is free-form.
+
+### 7) In-Memory Storage Path
+- **Pass**: Demo uses in-memory storage for orgs, coworkers, and emails (no DB required).
+- **Fail**: Demo requires external DB setup to run.
+
+### 8) Mocked Email Transport Path
+- **Pass**: All email send/receive operations are routed through the mocked transport layer (queue + scheduler).
+- **Fail**: Real SMTP/IMAP dependencies are required for the demo to run.
+
+### 9) Deterministic Demo Script
+- **Pass**: A documented local run path produces the full sequence in a predictable order.
+- **Fail**: Demo depends on manual, ad-hoc steps not captured in run instructions.
+
+### 10) Logging/Traceability
+- **Pass**: Console or log output shows key events: org created, coworker hired, task received, reply scheduled, reply sent.
+- **Fail**: No observable trace of state transitions.
+
+## Red-Line Scope Violations (Do Not Include)
+- Any real-time UI, web dashboard, or chat UX.
+- Live email server integration (SMTP/IMAP) or third-party mail providers.
+- Multi-user permissions, auth flows, or user management.
+- Persistent storage setup (databases, migrations, etc.).
+- Any non-email task creation surface (forms, REST endpoints used as primary UI).
+- Slack/Teams/Discord metaphors, presence indicators, or real-time collaboration features.
+
+## Notes
+- The demo is **email-only**. If a UI exists, it must be strictly optional and not required for any pass criteria.
+- Delays can be simulated, but the delay must be explicit and observable.

--- a/work/employee-05/tasks.md
+++ b/work/employee-05/tasks.md
@@ -4,3 +4,4 @@
 - [x] Produce MVP scope guardrails and execution plan.
 - [x] Produce v0 acceptance checklist and red-line scope warnings.
 - [x] Translate v0 acceptance checklist into QA scenarios.
+- [x] Produce demo acceptance checklist for mocked transport path.


### PR DESCRIPTION
### Motivation
- Provide explicit acceptance criteria for the runnable demo that uses a mocked email transport, in-memory storage, and scheduled delays to protect the email-first north star.
- Prevent scope creep by listing red-line violations (no real SMTP, no real-time UI, no persistent DB) for demo implementers.
- Ensure the demo is deterministic and thread-linked so the create→hire→task→delayed-reply loop can be validated.

### Description
- Added `work/employee-05/output/demo-acceptance-checklist.md` containing pass/fail criteria, red-line scope violations, and notes for the mocked transport demo.
- Updated `work/employee-05/tasks.md` to record the new deliverable (`Produce demo acceptance checklist for mocked transport path`).
- Updated `work/employee-05/decisions.md` to capture the demo acceptance criteria requirement for mocked transport, in-memory storage, delay scheduling, and thread-linked replies.
- Updated `work/employee-05/README.md` to reference the new demo acceptance checklist.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1136f22083209b56ba0174be9277)