### PR TITLE
Add demo mocked email transport and scheduler design

### DIFF
--- a/work/employee-04/README.md
+++ b/work/employee-04/README.md
@@ -10,3 +10,4 @@
 - Delivered a minimal runtime component map (ingest, parser, router, scheduler, sender).
 - Specified queue jobs with required payloads and delivery lifecycle events.
 - Listed required scheduling/context data to support delayed responses.
+- Defined the demo’s mocked email transport and scheduler design with in-memory queues and thread linkage fields.

--- a/work/employee-04/decisions.md
+++ b/work/employee-04/decisions.md
@@ -4,3 +4,4 @@
 - Treated forwards as new threads by default to avoid accidental context leakage.
 - Specified a single managed SMTP provider for inbound webhook + outbound relay in v0 to simplify deliverability and ops.
 - Chose a minimal five-service pipeline (ingest, parser, router, scheduler, sender) with explicit queue jobs and idempotency keys to support delayed responses.
+- For the demo, standardized on an in-memory transport + scheduler with explicit thread linkage fields (`threadId`, `inReplyTo`, `references`) to keep the reply in the same thread.

--- a/work/employee-04/output/demo-mock-transport.md
+++ b/work/employee-04/output/demo-mock-transport.md
@@ -1,0 +1,126 @@
+# Demo Mocked Email Transport + Scheduler Design
+
+## Purpose
+Provide a minimal, in-memory email transport and scheduler to power the demo flow:
+create org → hire coworker → send task email → schedule delayed reply → send reply in same thread.
+
+This design is intentionally simple (no external SMTP, no persistence) but keeps the same payload fields
+and thread linkage behavior we expect in the real system.
+
+---
+
+## Components (In-Memory)
+
+1. **MockTransport**
+   - Accepts outbound email payloads and stores them in a `sent[]` array.
+   - Emits `email.sent` events for inspection/testing.
+
+2. **MockInbox**
+   - Accepts inbound email payloads and stores them in a `received[]` array.
+   - Emits `email.received` events for routing into the system.
+
+3. **MockScheduler**
+   - Uses a `scheduled[]` array of jobs with `runAt` timestamps.
+   - Ticks via `setInterval` or manual `tick(now)` to execute due jobs.
+
+4. **ThreadStore**
+   - In-memory map keyed by `threadId` with `messageIds[]` and subject.
+   - Used to ensure replies include the correct `In-Reply-To` and `References`.
+
+---
+
+## Required Payload Fields
+
+### Email Message (Inbound/Outbound)
+```
+{
+  id: "msg_123",               // unique message id
+  orgId: "org_123",
+  from: "pm@demo.com",
+  to: ["coworker@demo.com"],
+  cc: [],
+  bcc: [],
+  subject: "Task: Draft launch email",
+  text: "...",
+  html: "..." | null,
+  threadId: "thr_123",         // derived or assigned
+  inReplyTo: "msg_001" | null,
+  references: ["msg_001", ...],
+  headers: {
+    "Message-ID": "msg_123",
+    "In-Reply-To": "msg_001"
+  },
+  createdAt: "2025-02-12T12:00:00Z"
+}
+```
+
+### Scheduled Job
+```
+{
+  id: "job_123",
+  type: "send_email",
+  runAt: "2025-02-12T12:05:00Z",
+  payload: {
+    orgId,
+    threadId,
+    message: { ...Email Message... }
+  }
+}
+```
+
+---
+
+## Thread Linkage Rules (Minimal)
+
+- If `inReplyTo` is set, reuse the original thread:
+  - `threadId` is the original thread’s id
+  - `references` append the new `inReplyTo` id
+- If `inReplyTo` is null, create a new `threadId`.
+- `ThreadStore` keeps:
+  - `threadId → { subject, messageIds[] }`.
+
+---
+
+## Scheduling Flow (Demo)
+
+1. Inbound task email enters `MockInbox`.
+2. Router decides coworker should respond after a delay (e.g., 3 minutes).
+3. Scheduler enqueues `send_email` job with `runAt = now + delay`.
+4. On tick, Scheduler dispatches job to `MockTransport`.
+5. `MockTransport` stores the sent reply in the `sent[]` array.
+6. Reply payload includes `inReplyTo` and `references` so it stays in the same thread.
+
+---
+
+## Suggested Local Dev Wiring
+
+- **Single process** Node script or dev server.
+- Use module-level in-memory arrays:
+  - `const sent = []`
+  - `const received = []`
+  - `const scheduled = []`
+  - `const threads = new Map()`
+
+### Example wiring (pseudo)
+```
+const transport = new MockTransport(sent);
+const scheduler = new MockScheduler(scheduled, (job) => {
+  if (job.type === "send_email") transport.send(job.payload.message);
+});
+
+mockInbox.on("email.received", (message) => {
+  const { threadId, inReplyTo, references } = threader.link(message, threads);
+  const reply = coworker.composeReply({ threadId, inReplyTo, references });
+  scheduler.schedule({ type: "send_email", runAt: Date.now() + 180000, payload: { message: reply } });
+});
+
+setInterval(() => scheduler.tick(Date.now()), 1000);
+```
+
+---
+
+## Notes for Demo Reliability
+
+- Make `MockScheduler` deterministic by allowing manual `tick(now)` calls for tests.
+- Expose the `sent[]` array to verify the reply body and thread headers.
+- Keep IDs explicit so the demo can assert that `reply.inReplyTo` matches the original task email.

--- a/work/employee-04/tasks.md
+++ b/work/employee-04/tasks.md
@@ -5,3 +5,4 @@
 - [x] Write deliverables to output/.
 - [x] Draft v0 inbound/outbound email pipeline spec.
 - [x] Define minimal runtime components, jobs, and delay-support data for the pipeline.
+- [x] Define minimal mocked email transport + scheduler design for demo.


### PR DESCRIPTION
### Motivation

- Provide a minimal, in-memory email transport and scheduler to power the demo flow (create org → hire coworker → send task email → schedule delayed reply → send reply in same thread).
- Keep demo wiring faithful to the v0 pipeline by preserving thread linkage and expected payload fields for testing and local development. 
- Reduce external dependencies for the demo so the flow can run deterministically in-process. 

### Description

- Added `work/employee-04/output/demo-mock-transport.md` describing `MockTransport`, `MockInbox`, `MockScheduler`, and `ThreadStore` plus required payload fields and thread linkage rules. 
- Standardized message/thread fields (`threadId`, `inReplyTo`, `references`, `headers`) and included example payloads and a `send_email` scheduled job shape. 
- Updated `work/employee-04/tasks.md` to mark the demo design task complete, appended a demo decision to `work/employee-04/decisions.md`, and updated `work/employee-04/README.md` end-of-task summary. 

### Testing

- No automated tests were added or executed for this change. 
- The design file includes suggestions for deterministic testing (manual `tick(now)` and exposable `sent[]` array) but those are documentation-only in this PR. 
- Validation performed: content files were created/updated and committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f112fbc848320b43f37116751499f)