### PR TITLE
Update demo loop to ingest email commands and add checklist logging

### DIFF
--- a/work/employee-01/README.md
+++ b/work/employee-01/README.md
@@ -6,3 +6,7 @@
 - Drafted v0 email command grammar for org/coworker management in output/.
 - Drafted the v0 org bootstrap and admin auth model for email commands in output/.
 - Implemented a runnable mocked email demo loop and wrote implementation notes in output/.
+
+## End of Task Summary
+- Updated the demo loop to parse email commands for org creation and coworker hire, with confirmation replies.
+- Aligned coworker reply formatting to the Work Notes + signature template and added checklist-step logging.

--- a/work/employee-01/decisions.md
+++ b/work/employee-01/decisions.md
@@ -5,3 +5,4 @@
 - Org creation is email-only, gated by sender allowlist or one-time bootstrap tokens tied to the admin email.
 - Implemented the demo loop as a self-contained Python script inside the employee output folder to avoid writing outside `work/` while still being runnable.
 - Used a simple sleep-based scheduler to model delayed replies without external dependencies.
+- 2025-12-26: Added explicit email command ingestion and checklist-step logging in the demo loop to mirror acceptance criteria while keeping mocked transport and in-memory storage.

--- a/work/employee-01/tasks.md
+++ b/work/employee-01/tasks.md
@@ -6,3 +6,4 @@
 - [x] Draft email command grammar v0 for org/coworker management.
 - [x] Draft v0 org bootstrap + admin auth model for email commands.
 - [x] Implement a runnable mocked email demo loop and write implementation notes.
+- [x] Update demo loop to ingest org/coworker email commands, align reply format, and add acceptance checklist logging.


### PR DESCRIPTION
### Motivation
- Align the runnable demo with the cycle-4 demo acceptance checklist by simulating email-command ingestion for org creation and coworker hire.
- Make coworker replies conform to the v0 demo format (Work Notes + signature) so the output is demo-ready.
- Surface explicit, observable checklist/log entries for each acceptance step so the mocked demo path is auditable.

### Description
- Updated `work/employee-01/output/demo_loop.py` to add `parse_command` and `handle_command_email` functions that ingest `CREATE ORG` and `HIRE COWORKER` email bodies and emit confirmation replies via the mocked transport.
- Added `control_email`, separate thread IDs (`thread-org-1001`, `thread-hire-1002`, `thread-task-1003`), a `log_checklist` helper to print acceptance-step logs, and a configurable `delay_seconds` used by the `Scheduler`.
- Aligned the coworker reply body to include a `Work Notes` section and signature, and ensured the reply is sent in the same thread with an `Re:` subject.
- Updated project metadata files: `work/employee-01/tasks.md` to reflect the change, `work/employee-01/decisions.md` to log the implementation decision, and `work/employee-01/README.md` with an End of Task Summary.

### Testing
- No automated tests were run for this change (demo script only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f14fd2b1c832090e02a61df03ffe8)