### PR TITLE
Add demo confirmation email templates

### DIFF
--- a/work/employee-02/README.md
+++ b/work/employee-02/README.md
@@ -10,3 +10,4 @@
 - Created system email templates for org creation, coworker hire confirmations, and command success/failure responses.
 - Logged the decision to keep templates minimal and neutral to align with "boring is good."
 - Delivered demo-ready email scripts covering org creation, coworker hire, task assignment, and coworker reply.
+- Added demo-ready subject/body templates for org creation and coworker hire confirmations.

--- a/work/employee-02/decisions.md
+++ b/work/employee-02/decisions.md
@@ -6,3 +6,4 @@
 - Standardized email templates around labeled sections (Goal, Scope, Constraints, Work Notes, Artifacts) so clarity is preserved without introducing UI beyond the email body.
 - Kept system notification templates minimal and neutral, with short labeled sections to preserve "boring is good" while making responses scannable.
 - Chose a minimal four-email demo script (org creation, hire confirmation, task assignment, coworker reply) with labeled sections to match v0 template format and keep tone neutral.
+- Added demo confirmation templates with explicit subject lines and labeled body sections to make org creation and coworker hire confirmations drop-in ready for the scripted demo.

--- a/work/employee-02/output/demo-confirmation-templates.md
+++ b/work/employee-02/output/demo-confirmation-templates.md
@@ -1,0 +1,56 @@
+# Demo Confirmation Templates (Org Creation + Coworker Hire)
+
+These templates are demo-ready for direct insertion into the script. Tone is neutral and sections are labeled for scan-ability.
+
+## 1) Organization Creation — Confirmation
+
+**Subject:** [Dopo] Organization created: {{org_name}}
+
+**Body:**
+Hello {{requester_name}},
+
+Your organization has been created.
+
+**Organization**
+- Name: {{org_name}}
+- Org ID: {{org_id}}
+
+**Owner**
+- Name: {{requester_name}}
+- Email: {{requester_email}}
+
+**Status**
+- Result: Created
+- Timestamp: {{timestamp}}
+
+If you want to hire coworkers, reply with: “Hire {{coworker_role}} named {{coworker_name}}.”
+
+—Dopo System
+
+---
+
+## 2) Coworker Hire — Confirmation
+
+**Subject:** [Dopo] Coworker hired: {{coworker_name}} ({{coworker_role}})
+
+**Body:**
+Hello {{requester_name}},
+
+Your coworker has been added to {{org_name}}.
+
+**Coworker**
+- Name: {{coworker_name}}
+- Role: {{coworker_role}}
+- Coworker ID: {{coworker_id}}
+
+**Organization**
+- Name: {{org_name}}
+- Org ID: {{org_id}}
+
+**Status**
+- Result: Hired
+- Timestamp: {{timestamp}}
+
+To assign work, reply with: “Task for {{coworker_name}}: {{task_summary}}.”
+
+—Dopo System

--- a/work/employee-02/tasks.md
+++ b/work/employee-02/tasks.md
@@ -10,3 +10,4 @@
 - [x] Log decisions for system email templates
 - [x] Update README with End of Task Summary
 - [x] Provide demo email scripts for org creation, coworker hire, task assignment, and coworker reply
+- [x] Provide demo-ready subject/body templates for org creation and coworker hire confirmations


### PR DESCRIPTION
### Motivation
- Provide drop-in, demo-ready subject/body templates for organization creation and coworker hire so the demo script can embed confirmations directly.
- Keep templates neutral and scanable with labeled sections to align with the product principle that "boring is good." 
- Make the demo flow explicit and reduce friction for the engineer integrating the demo by standardizing confirmation message format.

### Description
- Added a new file `work/employee-02/output/demo-confirmation-templates.md` containing org creation and coworker hire confirmation templates with explicit `Subject` and labeled body sections.
- Updated `work/employee-02/tasks.md` to mark the delivery of demo-ready subject/body templates as complete.
- Appended a note to `work/employee-02/decisions.md` documenting the addition of demo confirmation templates for drop-in use.
- Updated `work/employee-02/README.md` end-of-task summary to mention the newly added demo-ready templates.

### Testing
- No automated tests were run because these are content-only documentation templates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1505242c8320990a08b61377e3f6)