### PR TITLE
Add demo reply body template for cycle 4

### DIFF
--- a/work/employee-03/README.md
+++ b/work/employee-03/README.md
@@ -5,12 +5,14 @@
 - Provided good/bad email behavior examples for reference.
 - Defined a v0 response format and unified delay policy.
 - Drafted a demo-ready coworker reply prompt template with a filled-out sample.
+- Delivered a concise demo-ready reply body template for v0 responses.
 
 ## Outputs
 - `output/behavior-spec.md`
 - `output/email-examples.md`
 - `output/response-format-and-delay.md`
 - `output/demo-reply-prompt.md`
+- `output/demo-reply-body-template.md`
 
 ## End of Task Summary
-- Created a concrete prompt template and example reply for the demo, enforcing the v0 subject prefixes, Work Notes fields, and signature format.
+- Created a concise v0 reply body template with Work Notes, Questions, and signature for the cycle 4 demo.

--- a/work/employee-03/decisions.md
+++ b/work/employee-03/decisions.md
@@ -2,3 +2,4 @@
 - 2025-09-13: Set a v0 reply delay window of 90–180 minutes after read time to reconcile prior minutes-vs-hours guidance.
 - 2025-09-13: Updated v0 reply delay window to 5–30 minutes and clarified urgent-tone handling without shortening the delay.
 - 2025-09-13: Added a concrete demo reply prompt template with a filled-out example to enforce the v0 response format.
+- 2025-09-13: Added a concise demo-ready reply body template using Work Notes + Questions + signature for cycle 4.

--- a/work/employee-03/output/demo-reply-body-template.md
+++ b/work/employee-03/output/demo-reply-body-template.md
@@ -1,0 +1,17 @@
+# Demo Reply Body Template (v0)
+
+Quick note — I can take the first pass on this and will follow up if I hit any gaps.
+
+**Work Notes**
+- **Status:** In progress
+- **Assumptions:** None
+- **Blockers:** None
+- **Next Step:** Draft the initial outline and share a short update
+- **ETA:** Later today
+
+**Questions**
+1) Is there a preferred deadline I should aim for?
+2) Any examples or references I should mirror?
+
+— Alex
+AI Coworker (Role)

--- a/work/employee-03/tasks.md
+++ b/work/employee-03/tasks.md
@@ -5,3 +5,4 @@
 - [x] Define v0 response format and deterministic delay policy
 - [x] Update v0 delay window to 5–30 minutes with urgent-tone guidance
 - [x] Write demo coworker reply prompt template with sample reply for cycle 2
+- [x] Provide demo-ready reply body template matching v0 format for cycle 4


### PR DESCRIPTION
### Motivation
- Provide a concise, demo-ready reply body template that matches the v0 response format for the cycle-4 demo.
- Ensure the demo script can embed a standard coworker reply with `Work Notes`, `Questions`, and a simple signature verbatim.
- Keep workspace metadata accurate by recording the new artifact in the employee-03 files.

### Description
- Add `work/employee-03/output/demo-reply-body-template.md` containing a short reply with `Work Notes`, `Questions`, and a signature.
- Update `work/employee-03/README.md` to list the new output file and reflect the end-of-task summary.
- Update `work/employee-03/tasks.md` to mark the cycle-4 template task complete and append a decision to `work/employee-03/decisions.md` documenting the new template.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f150f18248320a14c133cb4dd2aea)