### PR TITLE
Add demo thread continuity log fields

### DIFF
--- a/work/employee-04/README.md
+++ b/work/employee-04/README.md
@@ -11,3 +11,4 @@
 - Specified queue jobs with required payloads and delivery lifecycle events.
 - Listed required scheduling/context data to support delayed responses.
 - Defined the demo’s mocked email transport and scheduler design with in-memory queues and thread linkage fields.
+- Specified minimal log fields (`thread_id`, `message_id`, `in_reply_to`, `references`, optional `subject`) to demonstrate thread continuity.

--- a/work/employee-04/decisions.md
+++ b/work/employee-04/decisions.md
@@ -5,3 +5,4 @@
 - Specified a single managed SMTP provider for inbound webhook + outbound relay in v0 to simplify deliverability and ops.
 - Chose a minimal five-service pipeline (ingest, parser, router, scheduler, sender) with explicit queue jobs and idempotency keys to support delayed responses.
 - For the demo, standardized on an in-memory transport + scheduler with explicit thread linkage fields (`threadId`, `inReplyTo`, `references`) to keep the reply in the same thread.
+- For demo logs, require `thread_id`, `message_id`, `in_reply_to`, and `references` (plus optional `subject`) to demonstrate continuity.

--- a/work/employee-04/output/thread-continuity-log-fields.md
+++ b/work/employee-04/output/thread-continuity-log-fields.md
@@ -1,0 +1,36 @@
+# Demo Thread Continuity Log Fields (Minimal)
+
+Purpose: when the mocked transport prints/logs a message event, include only the fields that demonstrate **thread continuity** across inbound → agent reply → subsequent replies. These should be stable across messages in the same thread and traceable back to the original inbound email.
+
+## Required fields to log per message
+
+1. **thread_id**
+   - Internal thread identifier used by the demo loop.
+   - Must remain identical across all messages in the same conversation.
+
+2. **message_id**
+   - Unique ID for this specific message.
+   - Useful for showing that each reply is a distinct message in the same thread.
+
+3. **in_reply_to**
+   - The `message_id` of the immediate parent message.
+   - Shows direct linkage to the prior message in the thread.
+
+4. **references**
+   - Ordered list of all ancestor `message_id` values in the thread.
+   - Demonstrates full thread lineage (can be printed as a single joined string).
+
+5. **subject** (optional but recommended)
+   - Keep unchanged or with standard `Re:` prefix.
+   - Helps humans visually confirm continuity without being the source of truth.
+
+## Suggested log format (one line)
+
+```
+[transport] thread=<thread_id> msg=<message_id> in-reply-to=<in_reply_to> refs=<references> subject="<subject>"
+```
+
+## Notes
+
+- If `in_reply_to` is empty (new inbound message), `references` should be empty and a new `thread_id` should be created.
+- For replies, `in_reply_to` must point to the most recent message in the thread; `references` should include all prior `message_id` values (including the parent).

--- a/work/employee-04/tasks.md
+++ b/work/employee-04/tasks.md
@@ -6,3 +6,4 @@
 - [x] Draft v0 inbound/outbound email pipeline spec.
 - [x] Define minimal runtime components, jobs, and delay-support data for the pipeline.
 - [x] Define minimal mocked email transport + scheduler design for demo.
+- [x] Specify minimal thread/header fields to log for demo thread continuity.


### PR DESCRIPTION
### Motivation

- The demo’s mocked transport needs a minimal, deterministic set of fields to demonstrate thread continuity across inbound → agent reply → subsequent replies.
- A concise logging spec reduces ambiguity for the demo loop and keeps the scope limited to observable outputs.
- This change is scoped as documentation for Employee 04’s email system deliverable.

### Description

- Added `work/employee-04/output/thread-continuity-log-fields.md` documenting required log fields: `thread_id`, `message_id`, `in_reply_to`, `references`, and optional `subject`.
- Updated `work/employee-04/decisions.md` to require these fields for demo logs.
- Updated `work/employee-04/tasks.md` to mark the logging-spec task complete.
- Updated `work/employee-04/README.md` end-of-task summary to reference the new log fields.

### Testing

- No automated tests were added for this documentation-only change.
- No automated tests were executed because the update only modifies documentation and metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f15175f0883208f3439067c3d7f4a)