### PR TITLE
Add demo design desk-check gaps report

### DIFF
--- a/work/employee-05/README.md
+++ b/work/employee-05/README.md
@@ -6,3 +6,7 @@
 - Added v0 acceptance checklist and red-line scope warnings to work/employee-05/output/v0-acceptance-checklist.md.
 - Translated v0 acceptance checklist into QA scenarios in work/employee-05/output/v0-qa-scenarios.md.
 - Added a demo acceptance checklist for the mocked transport path in work/employee-05/output/demo-acceptance-checklist.md.
+- Ran a desk-check against the updated demo design and documented PASS-blocking gaps in work/employee-05/output/demo-design-desk-check.md.
+
+## End of Task Summary
+- Reviewed the updated demo design notes against the demo acceptance checklist and identified PASS-blocking gaps (email-initiated org creation/hire, scheduled-time logging, and reply format).

--- a/work/employee-05/decisions.md
+++ b/work/employee-05/decisions.md
@@ -4,3 +4,4 @@
 - Explicitly banned any real-time UI, dashboards, and non-email integrations to prevent scope creep.
 - Interpreted the single model/provider check as verifying consistent model/provider identifiers across coworker responses when metadata is available.
 - Defined demo acceptance criteria that require mocked transport, in-memory storage, explicit delay scheduling, and thread-linked replies to protect the email-only loop.
+- Flagged missing email-initiated org creation/hire, scheduled-time logging, and reply format requirements as PASS-blocking gaps in the updated demo design.

--- a/work/employee-05/output/demo-design-desk-check.md
+++ b/work/employee-05/output/demo-design-desk-check.md
@@ -1,0 +1,27 @@
+# Demo Design Desk-Check (Against Demo Acceptance Checklist)
+
+## Source Design Reviewed
+- `work/employee-01/output/demo-implementation-notes.md`
+
+## Desk-Check Results (Gaps That Block PASS)
+
+### 1) Organization Creation (Email-Initiated)
+**Gap:** The design notes describe the flow (create org → hire coworker) but do not state that org creation is triggered by a **single email command** and confirmed via an email reply. This fails the explicit email-initiated requirement.
+
+### 2) Coworker Hire (Email-Initiated)
+**Gap:** The design notes do not specify that coworker creation is initiated by a **hire coworker email** and confirmed via email. It reads as a scripted step, not an email command.
+
+### 4) Delayed Reply Scheduling
+**Gap:** The design mentions a delay queue, but does not state that the **scheduled time is logged or surfaced**. The checklist requires an explicit, observable scheduled time.
+
+### 6) Required Reply Format (Demo Format)
+**Gap:** The design notes do not specify that the coworker reply uses the required **Work Notes + signature** format. Without explicit formatting, this fails the checklist requirement.
+
+## Items That Appear to PASS (Based on Design Notes)
+- Task assignment is threaded (`thread-1001`) and reply is in the same thread.
+- Mocked transport and in-memory storage are used.
+- Deterministic run path is documented.
+- Logging includes org creation, coworker hire, task received, and reply sent (though scheduled time logging is missing).
+
+## Summary
+The updated demo design is close to the checklist, but **fails** due to missing explicit email command ingestion for org creation/hire, missing scheduled time logging, and missing reply formatting requirements.

--- a/work/employee-05/tasks.md
+++ b/work/employee-05/tasks.md
@@ -5,3 +5,4 @@
 - [x] Produce v0 acceptance checklist and red-line scope warnings.
 - [x] Translate v0 acceptance checklist into QA scenarios.
 - [x] Produce demo acceptance checklist for mocked transport path.
+- [x] Run desk-check against updated demo design and list PASS-blocking gaps.


### PR DESCRIPTION
### Motivation

- Validate the existing demo design from `work/employee-01/output/demo-implementation-notes.md` against the demo acceptance checklist to ensure the mocked-transport demo can PASS end-to-end.
- Surface any PASS-blocking gaps so the implementation team can address scope/formatting/logging issues before demo runs.
- Preserve decision and task state for `employee-05` to keep scope discipline and traceability.

### Description

- Added a desk-check report at `work/employee-05/output/demo-design-desk-check.md` that enumerates PASS-blocking gaps found during review. 
- Updated `work/employee-05/tasks.md` to record the completed desk-check task. 
- Appended a decision note to `work/employee-05/decisions.md` documenting the flagged gaps. 
- Updated `work/employee-05/README.md` with an end-of-task summary referencing the new report. 

### Testing

- No automated tests were run for these documentation and task updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f151f1b2483209ae4331c71867344)