### PR TITLE
Review demo reply body against v0 template

### DIFF
--- a/work/employee-03/README.md
+++ b/work/employee-03/README.md
@@ -6,6 +6,7 @@
 - Defined a v0 response format and unified delay policy.
 - Drafted a demo-ready coworker reply prompt template with a filled-out sample.
 - Delivered a concise demo-ready reply body template for v0 responses.
+- Reviewed the demo script coworker reply body against the v0 template and documented deviations.
 
 ## Outputs
 - `output/behavior-spec.md`
@@ -13,6 +14,7 @@
 - `output/response-format-and-delay.md`
 - `output/demo-reply-prompt.md`
 - `output/demo-reply-body-template.md`
+- `output/cycle-5-demo-reply-body-review.md`
 
 ## End of Task Summary
-- Created a concise v0 reply body template with Work Notes, Questions, and signature for the cycle 4 demo.
+- Documented deviations between the demo script reply body and the v0 template (missing acknowledgment, Questions section, required Work Notes fields, and full signature).

--- a/work/employee-03/decisions.md
+++ b/work/employee-03/decisions.md
@@ -3,3 +3,4 @@
 - 2025-09-13: Updated v0 reply delay window to 5–30 minutes and clarified urgent-tone handling without shortening the delay.
 - 2025-09-13: Added a concrete demo reply prompt template with a filled-out example to enforce the v0 response format.
 - 2025-09-13: Added a concise demo-ready reply body template using Work Notes + Questions + signature for cycle 4.
+- 2025-09-13: Logged that the demo script reply body deviates from the v0 template (missing acknowledgment, Questions section, required fields, and signature format).

--- a/work/employee-03/output/cycle-5-demo-reply-body-review.md
+++ b/work/employee-03/output/cycle-5-demo-reply-body-review.md
@@ -1,0 +1,38 @@
+# Cycle 5 — Demo Reply Body Review (Employee 03)
+
+## Reference Template
+Source: `work/employee-03/output/demo-reply-body-template.md`
+
+Template requirements:
+- Opens with a quick acknowledgment line.
+- **Work Notes** section with fields:
+  - Status
+  - Assumptions
+  - Blockers
+  - Next Step
+  - ETA
+- **Questions** section with at least two numbered questions.
+- Signature in the format:
+  - Em dash + name
+  - Role line (e.g., `AI Coworker (Role)`)
+
+## Demo Script Reply Body
+Source: `work/employee-01/output/demo_loop.py` (function `send_delayed_reply`)
+
+Body used:
+```
+Work Notes:
+- Proposed subject: Welcome to Acme (Getting Started)
+- Body: Thanks for joining... (steps 1-3)
+
+-- Sam
+```
+
+## Deviations
+1. Missing opening acknowledgment line (e.g., “Quick note — …”).
+2. **Work Notes** section does not include required fields (Status, Assumptions, Blockers, Next Step, ETA).
+3. Missing **Questions** section entirely.
+4. Signature format does not include role line (`AI Coworker (Role)`), and uses `-- Sam` instead of the em dash line.
+
+## Conclusion
+The demo script reply body does **not** match the v0 demo reply template. It is missing required sections and formatting.

--- a/work/employee-03/tasks.md
+++ b/work/employee-03/tasks.md
@@ -6,3 +6,4 @@
 - [x] Update v0 delay window to 5–30 minutes with urgent-tone guidance
 - [x] Write demo coworker reply prompt template with sample reply for cycle 2
 - [x] Provide demo-ready reply body template matching v0 format for cycle 4
+- [x] Review demo script coworker reply body vs v0 template (cycle 5)


### PR DESCRIPTION
### Motivation
- Ensure the demo script coworker reply matches the v0 reply template in `work/employee-03/output/demo-reply-body-template.md`.
- Record any deviations so implementation owners can reconcile format and content differences.
- Keep `work/employee-03` records and task state accurate and discoverable.

### Description
- Added `work/employee-03/output/cycle-5-demo-reply-body-review.md` documenting concrete deviations between the demo reply and the v0 template.
- Updated `work/employee-03/README.md` to reference the cycle-5 review and its output file.
- Appended a note to `work/employee-03/decisions.md` logging that the demo script reply body deviates from the v0 template.
- Marked the review as completed in `work/employee-03/tasks.md`.

### Testing
- Executed the demo script with `python work/employee-01/output/demo_loop.py`, which ran and printed the acceptance checklist and scheduled reply events as expected.
- No automated tests were run specifically against the documentation-only changes, as this was an analysis-and-documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f186aecf883208be7728f798504f0)