### PR TITLE
Review transport logging for thread continuity

### DIFF
--- a/work/employee-04/README.md
+++ b/work/employee-04/README.md
@@ -12,3 +12,4 @@
 - Listed required scheduling/context data to support delayed responses.
 - Defined the demo’s mocked email transport and scheduler design with in-memory queues and thread linkage fields.
 - Specified minimal log fields (`thread_id`, `message_id`, `in_reply_to`, `references`, optional `subject`) to demonstrate thread continuity.
+- Reviewed demo transport logging and documented missing continuity fields for compliance.

--- a/work/employee-04/decisions.md
+++ b/work/employee-04/decisions.md
@@ -6,3 +6,4 @@
 - Chose a minimal five-service pipeline (ingest, parser, router, scheduler, sender) with explicit queue jobs and idempotency keys to support delayed responses.
 - For the demo, standardized on an in-memory transport + scheduler with explicit thread linkage fields (`threadId`, `inReplyTo`, `references`) to keep the reply in the same thread.
 - For demo logs, require `thread_id`, `message_id`, `in_reply_to`, and `references` (plus optional `subject`) to demonstrate continuity.
+- Confirmed demo transport logging must include `message_id`, `in_reply_to`, and `references` in addition to `thread_id` to meet the logging spec.

--- a/work/employee-04/output/cycle-5-transport-logging-review.md
+++ b/work/employee-04/output/cycle-5-transport-logging-review.md
@@ -1,0 +1,20 @@
+# Cycle 5 Transport Logging Review
+
+## Scope
+Reviewed the demo transport logging in `work/employee-01/output/demo_loop.py` to confirm thread continuity fields are logged.
+
+## Findings
+- Transport logging currently prints: `from`, `to`, `subject`, and `thread_id` in the `[send]` log line.
+- **Missing continuity fields:** `message_id`, `in_reply_to`, and `references` are **not** logged.
+
+## Required Fields to Add
+To comply with the thread continuity logging spec, add the following fields to the transport log output:
+- `message_id`
+- `in_reply_to`
+- `references`
+
+Optional field already present in log output:
+- `subject`
+
+## Compliance Status
+- **Not compliant** until `message_id`, `in_reply_to`, and `references` are logged alongside `thread_id`.

--- a/work/employee-04/tasks.md
+++ b/work/employee-04/tasks.md
@@ -7,3 +7,4 @@
 - [x] Define minimal runtime components, jobs, and delay-support data for the pipeline.
 - [x] Define minimal mocked email transport + scheduler design for demo.
 - [x] Specify minimal thread/header fields to log for demo thread continuity.
+- [x] Review demo transport logging for thread continuity fields and report missing fields.


### PR DESCRIPTION
### Motivation
- Ensure the demo mocked transport logs the minimal thread continuity fields required by the email system spec so replay and debugging work correctly.
- Verify that the runnable demo in `work/employee-01/output/demo_loop.py` emits the required metadata for thread continuity auditing.
- Surface missing fields so the demo and future implementations are compliant with `work/employee-04` logging requirements.

### Description
- Added `work/employee-04/output/cycle-5-transport-logging-review.md` documenting the transport logging review and the missing continuity fields (`message_id`, `in_reply_to`, `references`).
- Updated `work/employee-04/tasks.md` to record the completed review task.
- Recorded the logging compliance requirement in `work/employee-04/decisions.md` and noted the review in `work/employee-04/README.md`.

### Testing
- This is a documentation-only change and no automated tests were executed.
- No runtime or unit tests were modified or run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1873c4108320a0fcb555676306dd)