### PR TITLE
Review demo confirmation template mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 - Immediate next actions: Finalize org creation path, delay policy, and external email scope; complete email pipeline, command grammar, and template specs.
 - Key risks: Scope creep into web UI or dashboards, inconsistent async timing behavior, and unclear email command authentication.
 - Confidence level (low / medium / high): Medium
+- Cycle 5: Reviewed demo confirmation outputs against templates and logged mismatches.

--- a/work/employee-02/README.md
+++ b/work/employee-02/README.md
@@ -11,3 +11,4 @@
 - Logged the decision to keep templates minimal and neutral to align with "boring is good."
 - Delivered demo-ready email scripts covering org creation, coworker hire, task assignment, and coworker reply.
 - Added demo-ready subject/body templates for org creation and coworker hire confirmations.
+- Reviewed demo confirmation outputs against templates and logged mismatches for org creation and coworker hire.

--- a/work/employee-02/decisions.md
+++ b/work/employee-02/decisions.md
@@ -7,3 +7,4 @@
 - Kept system notification templates minimal and neutral, with short labeled sections to preserve "boring is good" while making responses scannable.
 - Chose a minimal four-email demo script (org creation, hire confirmation, task assignment, coworker reply) with labeled sections to match v0 template format and keep tone neutral.
 - Added demo confirmation templates with explicit subject lines and labeled body sections to make org creation and coworker hire confirmations drop-in ready for the scripted demo.
+- Logged confirmation-template mismatches as-is without proposing script edits to keep scope limited to review.

--- a/work/employee-02/output/cycle-5-confirmation-review.md
+++ b/work/employee-02/output/cycle-5-confirmation-review.md
@@ -1,0 +1,43 @@
+# Cycle 5 Demo Confirmation Review — Employee 02
+
+## Scope
+Compared the demo script’s org creation + coworker hire confirmation emails against the demo confirmation templates.
+
+## Findings
+
+### 1) Org Creation Confirmation
+**Template expected**: [Dopo] Organization created: {{org_name}} + labeled sections (Organization, Owner, Status) and a hire prompt.
+
+**Demo script output (handle_command_email)**
+- **Subject**: "Re: CREATE ORG"
+- **Body**:
+  - OK
+  - org_id: {{org_id}}
+  - name: {{org_name}}
+
+**Mismatches / missing fields**
+- Subject does not match template ([Dopo] Organization created: {{org_name}}).
+- Missing greeting (Hello {{requester_name}}).
+- Missing **Organization** section formatting and explicit label.
+- Missing **Owner** section (requester_name + requester_email).
+- Missing **Status** section (Result + Timestamp).
+- Missing hire follow-up instruction.
+
+### 2) Coworker Hire Confirmation
+**Template expected**: [Dopo] Coworker hired: {{coworker_name}} ({{coworker_role}}) + labeled sections (Coworker, Organization, Status) and a task prompt.
+
+**Demo script output (handle_command_email)**
+- **Subject**: "Re: HIRE COWORKER"
+- **Body**:
+  - OK
+  - coworker_id: {{coworker_id}}
+  - name: {{coworker_name}}
+  - role: {{coworker_role}}
+
+**Mismatches / missing fields**
+- Subject does not match template ([Dopo] Coworker hired: {{coworker_name}} ({{coworker_role}})).
+- Missing greeting (Hello {{requester_name}}).
+- Missing **Coworker** section formatting and explicit label.
+- Missing **Organization** section (org_name + org_id).
+- Missing **Status** section (Result + Timestamp).
+- Missing task follow-up instruction.

--- a/work/employee-02/tasks.md
+++ b/work/employee-02/tasks.md
@@ -11,3 +11,4 @@
 - [x] Update README with End of Task Summary
 - [x] Provide demo email scripts for org creation, coworker hire, task assignment, and coworker reply
 - [x] Provide demo-ready subject/body templates for org creation and coworker hire confirmations
+- [x] Review demo script confirmations vs demo templates and report mismatches


### PR DESCRIPTION
### Motivation
- Validate that the runnable demo script's confirmation emails match the v0 demo confirmation templates for org creation and coworker hire.
- Surface and document any mismatches without changing the demo script to keep the review scope limited.

### Description
- Added `work/employee-02/output/cycle-5-confirmation-review.md` containing a detailed comparison and listed mismatches for org creation and coworker hire confirmations.
- Updated `work/employee-02/README.md` and top-level `README.md` with a brief End-of-Task summary note about the review, and appended the task in `work/employee-02/tasks.md`.
- Logged the decision in `work/employee-02/decisions.md` that mismatches were recorded as-is without proposing edits to the demo script.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f18644150832092821c10462f82dc)