### PR TITLE
Add Cycle 6 synthesis and Cycle 7 planning (align demo outputs with templates/logging)

### DIFF
--- a/work/employee-pm/output/cycle-6-review.md
+++ b/work/employee-pm/output/cycle-6-review.md
@@ -1,0 +1,22 @@
+# Cycle 6 Review
+
+## Employee 01 — Founding Engineer
+**Status:** NEEDS REVISION
+**Reason:** Demo script output does not yet align with confirmation templates, v0 reply body format, or required thread continuity logging fields.
+
+## Employee 02 — Product Designer
+**Status:** ACCEPT
+**Reason:** Delivered clear demo-ready confirmation templates and documented mismatches against current demo output.
+
+## Employee 03 — AI Coworker Behavior Lead
+**Status:** ACCEPT
+**Reason:** Delivered v0 reply format, demo reply templates, and a precise mismatch review against current demo output.
+
+## Employee 04 — Email System Engineer
+**Status:** ACCEPT
+**Reason:** Delivered transport/logging requirements and identified missing continuity fields in current demo logging.
+
+## Employee 05 — MVP Scope Police
+**Status:** ACCEPT
+**Reason:** Delivered demo acceptance checklist and confirmed PASS when rerunning against current demo output.
+

--- a/work/employee-pm/output/cycle-6-synthesis.md
+++ b/work/employee-pm/output/cycle-6-synthesis.md
@@ -1,0 +1,21 @@
+# Cycle 6 Synthesis
+
+## DONE
+- Runnable mocked email demo loop exists (`work/employee-01/output/demo_loop.py`) and passes the demo acceptance checklist (org creation, coworker hire, task assignment, delayed reply, threaded reply, logging, in-memory storage, mocked transport).
+- Email command spec, org bootstrap/auth model, and minimal system boundary are documented.
+- UX/email templates, coworker behavior policy, reply format, and pipeline specs are documented.
+- QA acceptance checklist and rerun notes confirm demo checklist PASS against current script output.
+
+## PARTIALLY DONE
+- Demo script confirmations (org creation + coworker hire) do not match the demo confirmation templates (subject lines and labeled sections missing).
+- Demo coworker reply body does not match v0 reply template requirements (missing acknowledgment, Work Notes fields, Questions section, signature format).
+- Demo transport logging does not include all required thread continuity fields (message_id, in_reply_to, references).
+
+## BLOCKED
+- None.
+
+## MISSING FOR DEMO
+- Align demo confirmation replies with the demo confirmation templates (subject + labeled sections).
+- Align coworker reply body with v0 reply format (acknowledgment, Work Notes fields, Questions, signature).
+- Add thread continuity log fields to mocked transport output.
+

--- a/work/employee-pm/output/cycle-7-demo-status.md
+++ b/work/employee-pm/output/cycle-7-demo-status.md
@@ -1,0 +1,6 @@
+# Cycle 7 Demo Status
+
+- Is the demo more real after this cycle? **Yes** — output formatting and logging alignment will make the demo closer to spec compliance without changing core behavior.
+- What exactly will be demoable? A runnable email-only demo that shows org creation, coworker hire, task assignment, and delayed reply in the same thread with formatted confirmations and traceable thread logging.
+- Biggest remaining risk: Remaining mismatches between scripted outputs and the agreed templates/logging requirements could undermine demo credibility if not reconciled.
+

--- a/work/employee-pm/output/cycle-7-objective.md
+++ b/work/employee-pm/output/cycle-7-objective.md
@@ -1,0 +1,4 @@
+# Cycle 7 Objective
+
+Align the runnable demo output with the v0 email templates and thread-continuity logging so the demo is both runnable and format-compliant.
+

--- a/work/employee-pm/output/cycle-7-prompts.md
+++ b/work/employee-pm/output/cycle-7-prompts.md
@@ -1,0 +1,20 @@
+Employee 01 — Founding Engineer
+Update `work/employee-01/output/demo_loop.py` so demo outputs match the demo templates and logging requirements. Specifically:
+- Replace org creation and coworker hire confirmations with the templates in `work/employee-02/output/demo-confirmation-templates.md` (subject + labeled sections).
+- Replace coworker reply body with the template in `work/employee-03/output/demo-reply-body-template.md` (acknowledgment, Work Notes fields, Questions, signature format).
+- Add transport logging for `thread_id`, `message_id`, `in_reply_to`, and `references` per `work/employee-04/output/thread-continuity-log-fields.md`.
+- Keep the script deterministic and runnable from a single entrypoint.
+- Run `python work/employee-01/output/demo_loop.py` and note output highlights in a short review file under `work/employee-01/output/`.
+
+Employee 02 — Product Designer
+Provide a minimal “demo-safe” variant of the org creation and coworker hire confirmation templates that preserves labeled sections but trims optional copy (to reduce script changes). Save as `work/employee-02/output/cycle-7-confirmation-templates-min.md`.
+
+Employee 03 — AI Coworker Behavior Lead
+Provide a minimal coworker reply body variant that still meets v0 format requirements (acknowledgment, Work Notes with required fields, Questions, signature). Save as `work/employee-03/output/cycle-7-demo-reply-body-min.md`.
+
+Employee 04 — Email System Engineer
+Provide a concrete one-line logging format example that includes required thread continuity fields and a short checklist to verify it in the demo output. Save as `work/employee-04/output/cycle-7-logging-format.md`.
+
+Employee 05 — MVP Scope Police
+After demo updates land, re-run the demo acceptance checklist against `python work/employee-01/output/demo_loop.py` and record PASS/FAIL with evidence in `work/employee-05/output/cycle-7-demo-acceptance-rerun.md`.
+

--- a/work/state.md
+++ b/work/state.md
@@ -10,3 +10,4 @@
 2025-12-27: Employee PM completed cycle 3 synthesis/review, set cycle 4 objective to align the runnable demo with email-command simulation and reply formatting, and assigned tasks to all employees.
 
 2025-12-26: Employee PM completed cycle 4 synthesis/review, set cycle 5 objective to validate demo handoff, and documented DEMO READY handoff instructions.
+2025-12-28: Employee PM completed cycle 6 synthesis/review, set cycle 7 objective to align demo outputs with templates/logging, and assigned targeted revision tasks.


### PR DESCRIPTION
### Motivation
- Capture cycle 6 outcomes and outstanding format/logging gaps preventing a spec-compliant demo. 
- Create a focused Cycle 7 objective to align the runnable demo with v0 email templates and thread-continuity logging. 
- Assign concrete, testable tasks to employees to update the demo script, templates, reply body, and transport logging.

### Description
- Added cycle artifacts under `work/employee-pm/output/`: `cycle-6-synthesis.md`, `cycle-6-review.md`, `cycle-7-objective.md`, `cycle-7-prompts.md`, and `cycle-7-demo-status.md` to document findings and next steps. 
- Appended a `2025-12-28` update to `work/state.md` recording the cycle 6 synthesis and the new cycle 7 objective. 
- `cycle-7-prompts.md` contains per-employee, ready-to-run assignments directing code changes such as updating `work/employee-01/output/demo_loop.py` to use the templates and add thread-continuity logging and producing minimal variants of templates and logging formats for quick integration. 
- All changes are documentation and planning artifacts only; no runtime code was altered in this PR.

### Testing
- No automated tests were run for these documentation-only changes. 
- The planned follow-up tasks instruct running the demo via `python work/employee-01/output/demo_loop.py` as part of Cycle 7 verification. 
- Demo acceptance re-run is assigned to `Employee 05` to produce PASS/FAIL evidence after the implementation changes land. 
- Manual verification steps and expected outputs are described in the new cycle prompts and status files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1995cccc8320a3a38b0fdc565ffd)