### PR TITLE
Align demo loop outputs with cycle 7 templates and add thread-continuity logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
 - Key risks: Scope creep into web UI or dashboards, inconsistent async timing behavior, and unclear email command authentication.
 - Confidence level (low / medium / high): Medium
 - Cycle 5: Reviewed demo confirmation outputs against templates and logged mismatches.
+- Cycle 7: Updated demo loop outputs to match confirmation/reply templates and thread continuity logging; captured run highlights in employee output.

--- a/work/employee-01/README.md
+++ b/work/employee-01/README.md
@@ -11,3 +11,5 @@
 - Updated the demo loop to parse email commands for org creation and coworker hire, with confirmation replies.
 - Aligned coworker reply formatting to the Work Notes + signature template and added checklist-step logging.
 - Ran the demo script and confirmed all acceptance checklist steps appear in console output.
+- Updated org/coworker confirmations and coworker reply body to cycle 7 templates, plus transport thread continuity logging.
+- Ran the demo loop and captured cycle 7 output highlights in output review notes.

--- a/work/employee-01/decisions.md
+++ b/work/employee-01/decisions.md
@@ -7,3 +7,5 @@
 - Used a simple sleep-based scheduler to model delayed replies without external dependencies.
 - 2025-12-26: Added explicit email command ingestion and checklist-step logging in the demo loop to mirror acceptance criteria while keeping mocked transport and in-memory storage.
 - 2025-12-26: Verified demo script output includes checklist steps 1–10; no changes required.
+- 2025-12-28: Switched demo confirmations and coworker reply content to cycle 7 templates, using deterministic placeholders for timestamp and requester name.
+- 2025-12-28: Added deterministic thread continuity fields (message_id, in_reply_to, references) to transport logging.

--- a/work/employee-01/output/cycle-7-demo-loop-review.md
+++ b/work/employee-01/output/cycle-7-demo-loop-review.md
@@ -1,0 +1,14 @@
+# Cycle 7 Demo Loop Review
+
+Command:
+- `python work/employee-01/output/demo_loop.py`
+
+Output highlights:
+- Confirmation templates emitted with labeled sections and [Dopo] subjects for org creation and coworker hire.
+- Transport logs include `thread`, `msg`, `in-reply-to`, and `refs` fields for each message.
+- Coworker reply body uses the v0 template with acknowledgment, Work Notes fields, Questions, and signature.
+- Checklist steps 1–10 appear in order through the run.
+
+Sample log lines:
+- `[transport] thread=thread-org-1001 msg=thread-org-1001-msg-002 in-reply-to=thread-org-1001-msg-001 refs=thread-org-1001-msg-001 subject="[Dopo] Organization created: Acme"`
+- `[transport] thread=thread-task-1003 msg=thread-task-1003-msg-002 in-reply-to=thread-task-1003-msg-001 refs=thread-task-1003-msg-001 subject="Re: Task: Draft onboarding email flow"`

--- a/work/employee-01/tasks.md
+++ b/work/employee-01/tasks.md
@@ -8,3 +8,5 @@
 - [x] Implement a runnable mocked email demo loop and write implementation notes.
 - [x] Update demo loop to ingest org/coworker email commands, align reply format, and add acceptance checklist logging.
 - [x] Ran demo_loop.py and verified all acceptance checklist steps appear in console output.
+- [x] Aligned demo confirmations, reply body, and transport logging with cycle 7 templates/requirements.
+- [x] Ran demo_loop.py and recorded cycle 7 review notes in output.


### PR DESCRIPTION
### Motivation

- Ensure the mocked demo emits the cycle-7 confirmation/reply templates so outputs match design acceptance criteria.  
- Demonstrate explicit thread continuity in transport logs for easy verification of message linkage.  
- Keep the demo deterministic and runnable from a single entrypoint for automated verification.  

### Description

- Added per-thread `message_id` generation and fields `in_reply_to` and `references`, and printed a one-line transport log including `thread`, `msg`, `in-reply-to`, `refs`, and `subject` in `work/employee-01/output/demo_loop.py`.  
- Replaced org creation and coworker hire confirmation messages with the cycle-7 confirmation templates and subjects, and switched the coworker reply body to the v0 reply template with `Work Notes`, `Questions`, and signature.  
- Introduced deterministic placeholders (`requester_name`, `timestamp`) and `current_org_id` tracking to keep outputs stable for testing.  
- Updated documentation and metadata: `work/employee-01/tasks.md`, `work/employee-01/decisions.md`, `work/employee-01/README.md`, top-level `README.md`, and added `work/employee-01/output/cycle-7-demo-loop-review.md` with run highlights.  

### Testing

- Ran `python work/employee-01/output/demo_loop.py` and observed successful run with checklist steps printed (1–10) and scheduled reply executing.  
- Verified transport logs include `thread`, `msg`, `in-reply-to`, `refs`, and `subject` for each message as expected.  
- Confirmed confirmation messages use `[Dopo]` subjects and labeled body sections consistent with cycle-7 templates.  
- Created `work/employee-01/output/cycle-7-demo-loop-review.md` capturing sample log lines and output highlights.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1ab0ba6c8320b3c2bff2468f6f7e)