### PR TITLE
Add minimal demo confirmation templates for cycle 7

### DIFF
--- a/work/employee-02/README.md
+++ b/work/employee-02/README.md
@@ -12,3 +12,4 @@
 - Delivered demo-ready email scripts covering org creation, coworker hire, task assignment, and coworker reply.
 - Added demo-ready subject/body templates for org creation and coworker hire confirmations.
 - Reviewed demo confirmation outputs against templates and logged mismatches for org creation and coworker hire.
+- Provided minimal demo-safe confirmation templates for org creation and coworker hire to reduce script changes.

--- a/work/employee-02/decisions.md
+++ b/work/employee-02/decisions.md
@@ -8,3 +8,4 @@
 - Chose a minimal four-email demo script (org creation, hire confirmation, task assignment, coworker reply) with labeled sections to match v0 template format and keep tone neutral.
 - Added demo confirmation templates with explicit subject lines and labeled body sections to make org creation and coworker hire confirmations drop-in ready for the scripted demo.
 - Logged confirmation-template mismatches as-is without proposing script edits to keep scope limited to review.
+- Produced a minimal confirmation template variant that removes optional guidance lines while preserving labeled sections for demo safety.

--- a/work/employee-02/output/cycle-7-confirmation-templates-min.md
+++ b/work/employee-02/output/cycle-7-confirmation-templates-min.md
@@ -1,0 +1,52 @@
+# Cycle 7 — Minimal Demo Confirmation Templates
+
+These variants keep labeled sections but remove optional guidance to minimize script changes.
+
+## 1) Organization Creation — Confirmation (Minimal)
+
+**Subject:** [Dopo] Organization created: {{org_name}}
+
+**Body:**
+Hello {{requester_name}},
+
+Organization created.
+
+**Organization**
+- Name: {{org_name}}
+- Org ID: {{org_id}}
+
+**Owner**
+- Name: {{requester_name}}
+- Email: {{requester_email}}
+
+**Status**
+- Result: Created
+- Timestamp: {{timestamp}}
+
+—Dopo System
+
+---
+
+## 2) Coworker Hire — Confirmation (Minimal)
+
+**Subject:** [Dopo] Coworker hired: {{coworker_name}} ({{coworker_role}})
+
+**Body:**
+Hello {{requester_name}},
+
+Coworker hired.
+
+**Coworker**
+- Name: {{coworker_name}}
+- Role: {{coworker_role}}
+- Coworker ID: {{coworker_id}}
+
+**Organization**
+- Name: {{org_name}}
+- Org ID: {{org_id}}
+
+**Status**
+- Result: Hired
+- Timestamp: {{timestamp}}
+
+—Dopo System

--- a/work/employee-02/tasks.md
+++ b/work/employee-02/tasks.md
@@ -12,3 +12,4 @@
 - [x] Provide demo email scripts for org creation, coworker hire, task assignment, and coworker reply
 - [x] Provide demo-ready subject/body templates for org creation and coworker hire confirmations
 - [x] Review demo script confirmations vs demo templates and report mismatches
+- [x] Provide minimal demo-safe confirmation templates for org creation and coworker hire (cycle 7)


### PR DESCRIPTION
### Motivation
- Provide a demo-safe, minimal variant of the org creation and coworker hire confirmation templates to reduce required script changes for the cycle-7 demo.
- Preserve labeled sections (e.g., `Organization`, `Coworker`, `Status`) while trimming optional guidance and extra copy for determinism.
- Keep the change scoped to documentation and templates to avoid touching behavior or demo scripts.

### Description
- Added `work/employee-02/output/cycle-7-confirmation-templates-min.md` containing minimal confirmation templates for organization creation and coworker hire.
- Updated `work/employee-02/tasks.md` to mark the new minimal template task as completed.
- Updated `work/employee-02/decisions.md` to record the decision to produce a minimal template variant for demo safety.
- Updated `work/employee-02/README.md` end-of-task summary to mention the added minimal templates.

### Testing
- No automated tests were run because this is a documentation-only change. 
- Manual validation consisted of inspecting the new `cycle-7-confirmation-templates-min.md` file to ensure labeled sections and required placeholders were preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1abbb5e48320a78f308cfd97bd4d)