### PR TITLE
Add cycle-7 logging format example and checklist

### DIFF
--- a/work/employee-04/README.md
+++ b/work/employee-04/README.md
@@ -13,3 +13,4 @@
 - Defined the demo’s mocked email transport and scheduler design with in-memory queues and thread linkage fields.
 - Specified minimal log fields (`thread_id`, `message_id`, `in_reply_to`, `references`, optional `subject`) to demonstrate thread continuity.
 - Reviewed demo transport logging and documented missing continuity fields for compliance.
+- Added a concrete one-line transport log format example with a verification checklist for demo output.

--- a/work/employee-04/decisions.md
+++ b/work/employee-04/decisions.md
@@ -7,3 +7,4 @@
 - For the demo, standardized on an in-memory transport + scheduler with explicit thread linkage fields (`threadId`, `inReplyTo`, `references`) to keep the reply in the same thread.
 - For demo logs, require `thread_id`, `message_id`, `in_reply_to`, and `references` (plus optional `subject`) to demonstrate continuity.
 - Confirmed demo transport logging must include `message_id`, `in_reply_to`, and `references` in addition to `thread_id` to meet the logging spec.
+- Documented a one-line transport log format and checklist to verify thread continuity fields in the demo output.

--- a/work/employee-04/output/cycle-7-logging-format.md
+++ b/work/employee-04/output/cycle-7-logging-format.md
@@ -1,0 +1,12 @@
+# Cycle 7 — Thread Continuity Logging Format
+
+**One-line format example**
+```
+[transport] event=send thread_id=thr_00042 message_id=msg_00077 in_reply_to=msg_00012 references="msg_00001 msg_00005 msg_00012"
+```
+
+**Demo verification checklist**
+- Confirm each send/receive transport log line includes `thread_id`, `message_id`, `in_reply_to`, and `references`.
+- Verify `in_reply_to` is empty or `none` on the first message in a thread and populated on replies.
+- Verify `references` accumulates prior message IDs in chronological order.
+- Confirm `thread_id` stays identical across all messages in the same thread.

--- a/work/employee-04/tasks.md
+++ b/work/employee-04/tasks.md
@@ -8,3 +8,4 @@
 - [x] Define minimal mocked email transport + scheduler design for demo.
 - [x] Specify minimal thread/header fields to log for demo thread continuity.
 - [x] Review demo transport logging for thread continuity fields and report missing fields.
+- [x] Provide cycle-7 logging format example and demo checklist.


### PR DESCRIPTION
### Motivation
- Provide a concrete, demo-safe logging example to ensure thread continuity fields are present in transport logs for the cycle-7 demo.
- Make verification deterministic and easy for other demo contributors to check `thread_id`, `message_id`, `in_reply_to`, and `references` presence and semantics.
- Record the decision and task progress so the email pipeline and demo expectations are consistent across contributors.

### Description
- Add `work/employee-04/output/cycle-7-logging-format.md` containing a one-line transport log example and a 4-item demo verification checklist.
- Update `work/employee-04/tasks.md` to mark the cycle-7 logging format example task as completed with `- [x] Provide cycle-7 logging format example and demo checklist`.
- Append a note to `work/employee-04/decisions.md` documenting the one-line transport log format and checklist for verifying thread continuity.
- Update `work/employee-04/README.md` end-of-task summary to mention the added concrete logging example and verification checklist.

### Testing
- No automated tests were run for these documentation and tracking changes.
- The new files were added and committed to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1ac828d48320a17afac8508185cb)