### PR TITLE
Re-run cycle 7 demo acceptance checklist and record PASS results

### DIFF
--- a/work/employee-05/README.md
+++ b/work/employee-05/README.md
@@ -11,3 +11,6 @@
 ## End of Task Summary
 - Reviewed the updated demo design notes against the demo acceptance checklist and identified PASS-blocking gaps (email-initiated org creation/hire, scheduled-time logging, and reply format).
 - Re-ran the demo acceptance checklist against the runnable script output and confirmed PASS for all criteria.
+
+## End of Task Summary
+- Re-ran the demo acceptance checklist against `python work/employee-01/output/demo_loop.py` after cycle-7 updates and recorded PASS results for all criteria in work/employee-05/output/cycle-7-demo-acceptance-rerun.md.

--- a/work/employee-05/decisions.md
+++ b/work/employee-05/decisions.md
@@ -6,3 +6,4 @@
 - Defined demo acceptance criteria that require mocked transport, in-memory storage, explicit delay scheduling, and thread-linked replies to protect the email-only loop.
 - Flagged missing email-initiated org creation/hire, scheduled-time logging, and reply format requirements as PASS-blocking gaps in the updated demo design.
 - Confirmed the runnable demo script output satisfies all demo acceptance checklist items (PASS across all 10 criteria).
+- Re-ran the demo acceptance checklist after cycle-7 demo updates and confirmed PASS for all 10 criteria based on demo_loop output.

--- a/work/employee-05/output/cycle-7-demo-acceptance-rerun.md
+++ b/work/employee-05/output/cycle-7-demo-acceptance-rerun.md
@@ -1,0 +1,39 @@
+# Cycle 7 Demo Acceptance Checklist Rerun
+
+Date: 2025-09-02
+Source: `python work/employee-01/output/demo_loop.py`
+
+## Results
+
+1) **Organization Creation (Email-Initiated)** — **PASS**  
+   Evidence: `[checklist 1] Org created via email command (Acme).`
+
+2) **Coworker Hire (Email-Initiated)** — **PASS**  
+   Evidence: `[checklist 2] Coworker hired via email command (Sam, Engineer).`
+
+3) **Task Assignment Email (Threaded)** — **PASS**  
+   Evidence: `[checklist 3] Task assignment email stored with thread identifier.`
+
+4) **Delayed Reply Scheduling** — **PASS**  
+   Evidence: `[checklist 4] Reply scheduled with 1.5s delay.`
+
+5) **Reply Sent in Same Thread** — **PASS**  
+   Evidence: `[checklist 5] Reply sent in the same thread with Re: subject.`
+
+6) **Required Reply Format (Demo Format)** — **PASS**  
+   Evidence: `[checklist 6] Reply includes Work Notes section and signature.`
+
+7) **In-Memory Storage Path** — **PASS**  
+   Evidence: `[checklist 7] Using in-memory storage for orgs, coworkers, and threads.`
+
+8) **Mocked Email Transport Path** — **PASS**  
+   Evidence: `[checklist 8] Using mocked email transport for send/receive.`
+
+9) **Deterministic Demo Script** — **PASS**  
+   Evidence: `[checklist 9] Demo script runs deterministically from a single entrypoint.`
+
+10) **Logging/Traceability** — **PASS**  
+   Evidence: `[checklist 10] Console output includes key state transitions.`
+
+## Notes
+- The console output shows the full loop (org creation → hire → task → delay → reply) with explicit checklist confirmations.

--- a/work/employee-05/tasks.md
+++ b/work/employee-05/tasks.md
@@ -7,3 +7,5 @@
 - [x] Produce demo acceptance checklist for mocked transport path.
 - [x] Run desk-check against updated demo design and list PASS-blocking gaps.
 - [x] Re-run demo acceptance checklist against runnable script output and record PASS/FAIL.
+- [x] Re-run demo acceptance checklist after cycle-7 demo updates and record PASS/FAIL.
+- [x] Re-run demo acceptance checklist after cycle-7 demo updates and record PASS/FAIL.


### PR DESCRIPTION
### Motivation

- Validate that the cycle-7 demo updates preserve the email-only end-to-end loop and meet the demo acceptance criteria.
- Produce explicit, file-backed evidence of the rerun so agent memory and audit trails remain authoritative.
- Keep `employee-05` task and decision records up-to-date after the demo changes.

### Description

- Added `work/employee-05/output/cycle-7-demo-acceptance-rerun.md` containing PASS/FAIL results and evidence for all 10 demo checklist items.
- Updated `work/employee-05/tasks.md` to mark the cycle-7 rerun task as completed.
- Appended a note to `work/employee-05/decisions.md` recording that the rerun confirmed PASS for all criteria.
- Updated `work/employee-05/README.md` with an end-of-task summary referencing the rerun results.

### Testing

- Ran the deterministic demo script with `python work/employee-01/output/demo_loop.py` and captured console output as evidence.
- Verified all 10 checklist items passed based on the demo script output and recorded the findings in `work/employee-05/output/cycle-7-demo-acceptance-rerun.md`.
- Confirmed the rerun produced expected log lines for org creation, coworker hire, task receipt, scheduled delay, and reply send.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1acf20b483208409cf19497d4e19)